### PR TITLE
Update hiding draft articles in Pelican post

### DIFF
--- a/author/steven-maude.html
+++ b/author/steven-maude.html
@@ -81,6 +81,10 @@ stevenmaude.co.uk            </a>
     <span class="published">
         <time datetime="2015-05-31T20:16:00+01:00"> 2015-05-31</time>
     </span>
+            <span class="label label-default">Modified</span>
+            <span class="modified">
+                <time datetime="2015-06-01T13:53:00+01:00"> 2015-06-01</time>
+            </span>
 
 
 

--- a/category/2015.html
+++ b/category/2015.html
@@ -82,6 +82,10 @@ stevenmaude.co.uk            </a>
     <span class="published">
         <time datetime="2015-05-31T20:16:00+01:00"> 2015-05-31</time>
     </span>
+            <span class="label label-default">Modified</span>
+            <span class="modified">
+                <time datetime="2015-06-01T13:53:00+01:00"> 2015-06-01</time>
+            </span>
 
 
 

--- a/feeds/all.atom.xml
+++ b/feeds/all.atom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom"><title>stevenmaude.co.uk</title><link href="http://www.stevenmaude.co.uk/" rel="alternate"></link><link href="http://www.stevenmaude.co.uk/feeds/all.atom.xml" rel="self"></link><id>http://www.stevenmaude.co.uk/</id><updated>2015-05-31T20:16:00+01:00</updated><entry><title>Hiding draft articles in Pelican</title><link href="http://www.stevenmaude.co.uk/posts/hiding-draft-articles-in-pelican.html" rel="alternate"></link><updated>2015-05-31T20:16:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2015-05-31:posts/hiding-draft-articles-in-pelican.html</id><summary type="html">&lt;p&gt;What I thought I'd get done in a week, actually took about four
+<feed xmlns="http://www.w3.org/2005/Atom"><title>stevenmaude.co.uk</title><link href="http://www.stevenmaude.co.uk/" rel="alternate"></link><link href="http://www.stevenmaude.co.uk/feeds/all.atom.xml" rel="self"></link><id>http://www.stevenmaude.co.uk/</id><updated>2015-06-01T13:53:00+01:00</updated><entry><title>Hiding draft articles in Pelican</title><link href="http://www.stevenmaude.co.uk/posts/hiding-draft-articles-in-pelican.html" rel="alternate"></link><updated>2015-06-01T13:53:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2015-05-31:posts/hiding-draft-articles-in-pelican.html</id><summary type="html">&lt;p&gt;What I thought I'd get done in a week, actually took about four
 months. But I'm finally free of Blogger and have moved to
 &lt;a href="http://docs.getpelican.com"&gt;Pelican&lt;/a&gt; for creating my blog. I'll be
 writing more about how I migrated soon.&lt;/p&gt;
@@ -30,7 +30,12 @@ on a post before you officially publish it.&lt;/p&gt;
 if you're using &lt;code&gt;git&lt;/code&gt; to push new versions of your blog for publication.
 Add &lt;code&gt;drafts/&lt;/code&gt; to your &lt;code&gt;.gitignore&lt;/code&gt; and you'd have to make a deliberate
 effort to add them for publication.&lt;/p&gt;
-&lt;h2&gt;Using Pelican's &lt;code&gt;IGNORE_FILES&lt;/code&gt;&lt;/h2&gt;
+&lt;h2&gt;Stopping Pelican from seeing the draft posts&lt;/h2&gt;
+&lt;p&gt;The other option is to just prevent Pelican from seeing draft posts
+completely.&lt;/p&gt;
+&lt;p&gt;This does mean that they won't appear in your local preview of your
+site, not even as an unlinked page.&lt;/p&gt;
+&lt;h3&gt;Using Pelican's &lt;code&gt;IGNORE_FILES&lt;/code&gt;&lt;/h3&gt;
 &lt;p&gt;Putting "draft" in the filename of any drafts is another option. Then,
 you can use the &lt;code&gt;IGNORE_FILES&lt;/code&gt; setting in &lt;code&gt;pelicanconf.py&lt;/code&gt; to
 specifically ignore the drafts.&lt;/p&gt;
@@ -41,8 +46,7 @@ unintentionally change your configuration.&lt;/p&gt;
 &lt;p&gt;For instance, the &lt;a href="http://docs.getpelican.com/en/latest/settings.html"&gt;default&lt;/a&gt;
 &lt;code&gt;IGNORE_FILES&lt;/code&gt; setting is &lt;code&gt;IGNORE_FILES = ['.#*']&lt;/code&gt; so we'll need to
 add &lt;code&gt;IGNORE_FILES = ['.#*', '*draft*']&lt;/code&gt; to our Pelican settings.&lt;/p&gt;
-&lt;h2&gt;Hiding them completely (in Ubuntu, at least)&lt;/h2&gt;
-&lt;p&gt;Another option is to just hide draft files from Pelican completely.&lt;/p&gt;
+&lt;h3&gt;Hiding the files completely (in Ubuntu, at least)&lt;/h3&gt;
 &lt;p&gt;Under Linux, I thought that preceding the filename with a dot would hide
 posts from Pelican, but it doesn't seem to. However, sticking a tilde on
 the end of the filename does seem to prevent Pelican from seeing the

--- a/index.html
+++ b/index.html
@@ -94,6 +94,10 @@ stevenmaude.co.uk            </a>
     <span class="published">
         <time datetime="2015-05-31T20:16:00+01:00"> 2015-05-31</time>
     </span>
+            <span class="label label-default">Modified</span>
+            <span class="modified">
+                <time datetime="2015-06-01T13:53:00+01:00"> 2015-06-01</time>
+            </span>
 
 
 

--- a/posts/hiding-draft-articles-in-pelican.html
+++ b/posts/hiding-draft-articles-in-pelican.html
@@ -98,6 +98,10 @@ stevenmaude.co.uk            </a>
     <span class="published">
         <time datetime="2015-05-31T20:16:00+01:00"> 2015-05-31</time>
     </span>
+            <span class="label label-default">Modified</span>
+            <span class="modified">
+                <time datetime="2015-06-01T13:53:00+01:00"> 2015-06-01</time>
+            </span>
 
 
 
@@ -143,7 +147,12 @@ on a post before you officially publish it.</p>
 if you're using <code>git</code> to push new versions of your blog for publication.
 Add <code>drafts/</code> to your <code>.gitignore</code> and you'd have to make a deliberate
 effort to add them for publication.</p>
-<h2>Using Pelican's <code>IGNORE_FILES</code></h2>
+<h2>Stopping Pelican from seeing the draft posts</h2>
+<p>The other option is to just prevent Pelican from seeing draft posts
+completely.</p>
+<p>This does mean that they won't appear in your local preview of your
+site, not even as an unlinked page.</p>
+<h3>Using Pelican's <code>IGNORE_FILES</code></h3>
 <p>Putting "draft" in the filename of any drafts is another option. Then,
 you can use the <code>IGNORE_FILES</code> setting in <code>pelicanconf.py</code> to
 specifically ignore the drafts.</p>
@@ -154,8 +163,7 @@ unintentionally change your configuration.</p>
 <p>For instance, the <a href="http://docs.getpelican.com/en/latest/settings.html">default</a>
 <code>IGNORE_FILES</code> setting is <code>IGNORE_FILES = ['.#*']</code> so we'll need to
 add <code>IGNORE_FILES = ['.#*', '*draft*']</code> to our Pelican settings.</p>
-<h2>Hiding them completely (in Ubuntu, at least)</h2>
-<p>Another option is to just hide draft files from Pelican completely.</p>
+<h3>Hiding the files completely (in Ubuntu, at least)</h3>
 <p>Under Linux, I thought that preceding the filename with a dot would hide
 posts from Pelican, but it doesn't seem to. However, sticking a tilde on
 the end of the filename does seem to prevent Pelican from seeing the

--- a/tag/article.html
+++ b/tag/article.html
@@ -82,6 +82,10 @@ stevenmaude.co.uk            </a>
     <span class="published">
         <time datetime="2015-05-31T20:16:00+01:00"> 2015-05-31</time>
     </span>
+            <span class="label label-default">Modified</span>
+            <span class="modified">
+                <time datetime="2015-06-01T13:53:00+01:00"> 2015-06-01</time>
+            </span>
 
 
 

--- a/tag/draft.html
+++ b/tag/draft.html
@@ -82,6 +82,10 @@ stevenmaude.co.uk            </a>
     <span class="published">
         <time datetime="2015-05-31T20:16:00+01:00"> 2015-05-31</time>
     </span>
+            <span class="label label-default">Modified</span>
+            <span class="modified">
+                <time datetime="2015-06-01T13:53:00+01:00"> 2015-06-01</time>
+            </span>
 
 
 

--- a/tag/pelican.html
+++ b/tag/pelican.html
@@ -82,6 +82,10 @@ stevenmaude.co.uk            </a>
     <span class="published">
         <time datetime="2015-05-31T20:16:00+01:00"> 2015-05-31</time>
     </span>
+            <span class="label label-default">Modified</span>
+            <span class="modified">
+                <time datetime="2015-06-01T13:53:00+01:00"> 2015-06-01</time>
+            </span>
 
 
 


### PR DESCRIPTION
Clarify what happens when you hide articles from Pelican by
IGNORE_FILES or marking as hidden in filesystem. They aren't included
in the build of your site.
