### PR TITLE
Update to Pelican 3.6.0

### DIFF
--- a/tags.html
+++ b/tags.html
@@ -227,11 +227,11 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-android" class="panel-collapse collapse">
                     <div class="panel-body">
+                        <p><span class="categories-timestamp"><time datetime="2014-08-25T15:42:00+01:00">2014-08-25</time></span> <a href="http://www.stevenmaude.co.uk/posts/updating-and-rooting-moto-g">Updating and rooting Moto G</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-04-05T10:21:00+01:00">2014-04-05</time></span> <a href="http://www.stevenmaude.co.uk/posts/android-device-encryption-is-mostly-good">Android device encryption is (mostly) good</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-03-28T21:56:00+00:00">2014-03-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/phone-upgrades-and-privacy-downgrades">Phone upgrades and privacy downgrades</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-06-28T21:03:00+01:00">2013-06-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/leaky-phone-apps">Leaky phone apps</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-05-11T14:26:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/patching-android-roms-for-pdroid-using">Patching Android ROMs for PDroid using Auto-Patcher</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-03-28T21:56:00+00:00">2014-03-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/phone-upgrades-and-privacy-downgrades">Phone upgrades and privacy downgrades</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-08-25T15:42:00+01:00">2014-08-25</time></span> <a href="http://www.stevenmaude.co.uk/posts/updating-and-rooting-moto-g">Updating and rooting Moto G</a></p>
                     </div>
                 </div>
             </div>
@@ -243,8 +243,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-annoyance" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-05-17T12:10:00+01:00">2013-05-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/firefox-21-annoyances">Firefox 21 annoyances</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-01-11T23:51:00+00:00">2014-01-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-delete-directories-that-respawn">How to delete directories that respawn in Windows 7</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-05-17T12:10:00+01:00">2013-05-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/firefox-21-annoyances">Firefox 21 annoyances</a></p>
                     </div>
                 </div>
             </div>
@@ -328,8 +328,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-auto-patcher" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-05-11T14:26:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/patching-android-roms-for-pdroid-using">Patching Android ROMs for PDroid using Auto-Patcher</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-03-28T21:56:00+00:00">2014-03-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/phone-upgrades-and-privacy-downgrades">Phone upgrades and privacy downgrades</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-05-11T14:26:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/patching-android-roms-for-pdroid-using">Patching Android ROMs for PDroid using Auto-Patcher</a></p>
                     </div>
                 </div>
             </div>
@@ -341,8 +341,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-backup" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-10-13T20:36:00+01:00">2013-10-13</time></span> <a href="http://www.stevenmaude.co.uk/posts/odd-behaviour-of-bitlocker-or-maybe-my">Odd behaviour of Bitlocker, or maybe my HDD...</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
                     </div>
                 </div>
             </div>
@@ -414,10 +414,10 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-bitlocker" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-10-13T20:36:00+01:00">2013-10-13</time></span> <a href="http://www.stevenmaude.co.uk/posts/odd-behaviour-of-bitlocker-or-maybe-my">Odd behaviour of Bitlocker, or maybe my HDD...</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-12-31T11:52:00+00:00">2013-12-31</time></span> <a href="http://www.stevenmaude.co.uk/posts/things-ive-learned-from-building-and">Things I've learned from building (and rebuilding) a PC.</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-10-13T20:36:00+01:00">2013-10-13</time></span> <a href="http://www.stevenmaude.co.uk/posts/odd-behaviour-of-bitlocker-or-maybe-my">Odd behaviour of Bitlocker, or maybe my HDD...</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
                     </div>
                 </div>
             </div>
@@ -465,8 +465,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-blogger" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-05-11T12:55:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/blogger-versus-wordpress">Blogger versus WordPress</a></p>
                         <p><span class="categories-timestamp"><time datetime="2015-06-06T14:46:00+01:00">2015-06-06</time></span> <a href="http://www.stevenmaude.co.uk/posts/blogger-versus-wordpress-revisited">Blogger versus Wordpress revisited</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-05-11T12:55:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/blogger-versus-wordpress">Blogger versus WordPress</a></p>
                     </div>
                 </div>
             </div>
@@ -478,8 +478,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-blogging" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-05-11T12:55:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/blogger-versus-wordpress">Blogger versus WordPress</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-03-22T14:55:00+00:00">2014-03-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/full-circle">Full circle</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-05-11T12:55:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/blogger-versus-wordpress">Blogger versus WordPress</a></p>
                     </div>
                 </div>
             </div>
@@ -527,8 +527,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-bug" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-10-13T20:36:00+01:00">2013-10-13</time></span> <a href="http://www.stevenmaude.co.uk/posts/odd-behaviour-of-bitlocker-or-maybe-my">Odd behaviour of Bitlocker, or maybe my HDD...</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-04-08T21:24:00+01:00">2014-04-08</time></span> <a href="http://www.stevenmaude.co.uk/posts/rockbox-ipod-nano-2g-and-inverted-audio">Rockbox, iPod Nano 2G and inverted audio channels</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-10-13T20:36:00+01:00">2013-10-13</time></span> <a href="http://www.stevenmaude.co.uk/posts/odd-behaviour-of-bitlocker-or-maybe-my">Odd behaviour of Bitlocker, or maybe my HDD...</a></p>
                     </div>
                 </div>
             </div>
@@ -662,8 +662,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-coding" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-03-21T22:53:00+00:00">2014-03-21</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-give-back-to-open-source-software">How to give back to open source software</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
                     </div>
                 </div>
             </div>
@@ -759,11 +759,11 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-data" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2014-01-14T18:35:00+00:00">2014-01-14</time></span> <a href="http://www.stevenmaude.co.uk/posts/book-review-data-science-for-business">Book review: "Data Science for Business"</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-06-22T21:47:00+01:00">2014-06-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/chatting-about-data-science-careers">Chatting about data science careers</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-06-24T21:05:00+01:00">2013-06-24</time></span> <a href="http://www.stevenmaude.co.uk/posts/courseras-introduction-to-data-science">Coursera's Introduction to Data Science course</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-06-28T21:03:00+01:00">2013-06-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/leaky-phone-apps">Leaky phone apps</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-01-14T18:35:00+00:00">2014-01-14</time></span> <a href="http://www.stevenmaude.co.uk/posts/book-review-data-science-for-business">Book review: "Data Science for Business"</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-07-02T17:22:00+01:00">2013-07-02</time></span> <a href="http://www.stevenmaude.co.uk/posts/types-of-data-scientist">Types of data scientist</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-06-28T21:03:00+01:00">2013-06-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/leaky-phone-apps">Leaky phone apps</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-06-24T21:05:00+01:00">2013-06-24</time></span> <a href="http://www.stevenmaude.co.uk/posts/courseras-introduction-to-data-science">Coursera's Introduction to Data Science course</a></p>
                     </div>
                 </div>
             </div>
@@ -823,8 +823,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-development" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-09-19T17:53:00+01:00">2013-09-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenvwrapper-in">Explaining Python virtualenvwrapper (in a couple of minutes)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
                     </div>
                 </div>
             </div>
@@ -920,9 +920,9 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-drive" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-10-13T20:36:00+01:00">2013-10-13</time></span> <a href="http://www.stevenmaude.co.uk/posts/odd-behaviour-of-bitlocker-or-maybe-my">Odd behaviour of Bitlocker, or maybe my HDD...</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
                     </div>
                 </div>
             </div>
@@ -970,10 +970,10 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-encryption" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-04-05T10:21:00+01:00">2014-04-05</time></span> <a href="http://www.stevenmaude.co.uk/posts/android-device-encryption-is-mostly-good">Android device encryption is (mostly) good</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-12-24T00:04:00+00:00">2013-12-24</time></span> <a href="http://www.stevenmaude.co.uk/posts/some-spring-winter-ubuntu-cleaning">Some <s>spring</s> winter Ubuntu cleaning</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
                     </div>
                 </div>
             </div>
@@ -997,8 +997,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-erase" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-08-29T22:32:00+01:00">2013-08-29</time></span> <a href="http://www.stevenmaude.co.uk/posts/dariks-boot-and-nuke-unrecognized">Darik's Boot and Nuke: fixing an "unrecognized device" error</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-01-04T11:22:00+00:00">2014-01-04</time></span> <a href="http://www.stevenmaude.co.uk/posts/securely-erasing-ssd-drives">Securely erasing SSD drives</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-08-29T22:32:00+01:00">2013-08-29</time></span> <a href="http://www.stevenmaude.co.uk/posts/dariks-boot-and-nuke-unrecognized">Darik's Boot and Nuke: fixing an "unrecognized device" error</a></p>
                     </div>
                 </div>
             </div>
@@ -1070,10 +1070,10 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-fix" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2014-07-05T11:34:00+01:00">2014-07-05</time></span> <a href="http://www.stevenmaude.co.uk/posts/arduous-lessons-in-python-why-main-is">Arduous lessons in Python: why main() is useful</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-11-10T16:49:00+00:00">2013-11-10</time></span> <a href="http://www.stevenmaude.co.uk/posts/its-not-often-that-i-think-of-technical">It's not often that I think of technical fixes as favourites, but...</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-07-29T23:15:00+01:00">2014-07-29</time></span> <a href="http://www.stevenmaude.co.uk/posts/my-wifis-connected-but-theres-no">My wifi's connected, but there's no internet...? (Intel Centrino versus Ubuntu)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-07-05T11:34:00+01:00">2014-07-05</time></span> <a href="http://www.stevenmaude.co.uk/posts/arduous-lessons-in-python-why-main-is">Arduous lessons in Python: why main() is useful</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-12-11T10:36:00+00:00">2013-12-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/windows-update-locking-up-on-xp-when">Windows Update locking up on XP when checking for updates: fixing the svchost.exe CPU usage problem</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-11-10T16:49:00+00:00">2013-11-10</time></span> <a href="http://www.stevenmaude.co.uk/posts/its-not-often-that-i-think-of-technical">It's not often that I think of technical fixes as favourites, but...</a></p>
                     </div>
                 </div>
             </div>
@@ -1181,8 +1181,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-github" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-09-07T11:48:00+01:00">2013-09-07</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-access-github-over-ssh-on-ubuntu">How to access GitHub over SSH on Ubuntu</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-10-08T19:33:00+01:00">2013-10-08</time></span> <a href="http://www.stevenmaude.co.uk/posts/working-with-multiple-ssh-keys-setting">Working with multiple SSH keys: setting up git over SSH with GitHub and Bitbucket</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-07T11:48:00+01:00">2013-09-07</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-access-github-over-ssh-on-ubuntu">How to access GitHub over SSH on Ubuntu</a></p>
                     </div>
                 </div>
             </div>
@@ -1218,8 +1218,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-hdd" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-08-29T22:32:00+01:00">2013-08-29</time></span> <a href="http://www.stevenmaude.co.uk/posts/dariks-boot-and-nuke-unrecognized">Darik's Boot and Nuke: fixing an "unrecognized device" error</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-08-29T22:32:00+01:00">2013-08-29</time></span> <a href="http://www.stevenmaude.co.uk/posts/dariks-boot-and-nuke-unrecognized">Darik's Boot and Nuke: fixing an "unrecognized device" error</a></p>
                     </div>
                 </div>
             </div>
@@ -1400,9 +1400,9 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-job" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-05-25T18:32:00+01:00">2013-05-25</time></span> <a href="http://www.stevenmaude.co.uk/posts/close-to-edit-what-researchers-can">Close to the edit: what researchers can learn from journal editing</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-11-03T13:23:00+00:00">2013-11-03</time></span> <a href="http://www.stevenmaude.co.uk/posts/differences-between-working-in">Differences between working in university research and a tech startup</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-08-18T22:20:00+01:00">2013-08-18</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-universities-can-help-develop">How universities can help develop researchers' post-university careers</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-05-25T18:32:00+01:00">2013-05-25</time></span> <a href="http://www.stevenmaude.co.uk/posts/close-to-edit-what-researchers-can">Close to the edit: what researchers can learn from journal editing</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-05-23T17:31:00+01:00">2013-05-23</time></span> <a href="http://www.stevenmaude.co.uk/posts/job-advertisements">Job advertisements</a></p>
                     </div>
                 </div>
@@ -1487,8 +1487,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-laptop" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2014-01-16T18:24:00+00:00">2014-01-16</time></span> <a href="http://www.stevenmaude.co.uk/posts/beatmatching-five-reasons-why-digital">Beatmatching; five reasons why digital DJs should learn, and how Traktor can help</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-03-17T19:04:00+00:00">2014-03-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/the-death-of-desktop-pc">The death of the desktop PC?</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-01-16T18:24:00+00:00">2014-01-16</time></span> <a href="http://www.stevenmaude.co.uk/posts/beatmatching-five-reasons-why-digital">Beatmatching; five reasons why digital DJs should learn, and how Traktor can help</a></p>
                     </div>
                 </div>
             </div>
@@ -1560,8 +1560,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-linux" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-01-31T12:59:00+00:00">2014-01-31</time></span> <a href="http://www.stevenmaude.co.uk/posts/ensuring-scheduled-cron-jobs-are-run">Ensuring scheduled cron jobs are run using anacron</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
                     </div>
                 </div>
@@ -1682,8 +1682,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-moto" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2014-03-28T21:56:00+00:00">2014-03-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/phone-upgrades-and-privacy-downgrades">Phone upgrades and privacy downgrades</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-08-25T15:42:00+01:00">2014-08-25</time></span> <a href="http://www.stevenmaude.co.uk/posts/updating-and-rooting-moto-g">Updating and rooting Moto G</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-03-28T21:56:00+00:00">2014-03-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/phone-upgrades-and-privacy-downgrades">Phone upgrades and privacy downgrades</a></p>
                     </div>
                 </div>
             </div>
@@ -1840,9 +1840,9 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-pdroid" class="panel-collapse collapse">
                     <div class="panel-body">
+                        <p><span class="categories-timestamp"><time datetime="2014-03-28T21:56:00+00:00">2014-03-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/phone-upgrades-and-privacy-downgrades">Phone upgrades and privacy downgrades</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-06-28T21:03:00+01:00">2013-06-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/leaky-phone-apps">Leaky phone apps</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-05-11T14:26:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/patching-android-roms-for-pdroid-using">Patching Android ROMs for PDroid using Auto-Patcher</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-03-28T21:56:00+00:00">2014-03-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/phone-upgrades-and-privacy-downgrades">Phone upgrades and privacy downgrades</a></p>
                     </div>
                 </div>
             </div>
@@ -1854,8 +1854,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-pelican" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2014-03-22T14:55:00+00:00">2014-03-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/full-circle">Full circle</a></p>
                         <p><span class="categories-timestamp"><time datetime="2015-05-31T20:16:00+01:00">2015-05-31</time></span> <a href="http://www.stevenmaude.co.uk/posts/hiding-draft-articles-in-pelican">Hiding draft articles in Pelican</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-03-22T14:55:00+00:00">2014-03-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/full-circle">Full circle</a></p>
                     </div>
                 </div>
             </div>
@@ -1880,8 +1880,8 @@ stevenmaude.co.uk            </a>
                 <div id="collapse-pi" class="panel-collapse collapse">
                     <div class="panel-body">
                         <p><span class="categories-timestamp"><time datetime="2014-01-31T12:59:00+00:00">2014-01-31</time></span> <a href="http://www.stevenmaude.co.uk/posts/ensuring-scheduled-cron-jobs-are-run">Ensuring scheduled cron jobs are run using anacron</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-07-10T21:21:00+01:00">2013-07-10</time></span> <a href="http://www.stevenmaude.co.uk/posts/uses-for-a-raspberry-pi-part-1">Uses for a Raspberry Pi (part 1)</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-07-17T19:32:00+01:00">2013-07-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/uses-for-a-raspberry-pi-part-2">Uses for a Raspberry Pi (part 2)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-07-10T21:21:00+01:00">2013-07-10</time></span> <a href="http://www.stevenmaude.co.uk/posts/uses-for-a-raspberry-pi-part-1">Uses for a Raspberry Pi (part 1)</a></p>
                     </div>
                 </div>
             </div>
@@ -1953,8 +1953,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-privacy" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-06-28T21:03:00+01:00">2013-06-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/leaky-phone-apps">Leaky phone apps</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-09-28T00:02:00+01:00">2014-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/taking-control-of-chromium-and-chrome">Taking control of Chromium (and Chrome) with µblock and HTTP Switchboard</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-06-28T21:03:00+01:00">2013-06-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/leaky-phone-apps">Leaky phone apps</a></p>
                     </div>
                 </div>
             </div>
@@ -2027,16 +2027,16 @@ stevenmaude.co.uk            </a>
                 <div id="collapse-python" class="panel-collapse collapse">
                     <div class="panel-body">
                         <p><span class="categories-timestamp"><time datetime="2014-07-05T11:34:00+01:00">2014-07-05</time></span> <a href="http://www.stevenmaude.co.uk/posts/arduous-lessons-in-python-why-main-is">Arduous lessons in Python: why main() is useful</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-05-09T21:29:00+01:00">2014-05-09</time></span> <a href="http://www.stevenmaude.co.uk/posts/beware-pythons-pyc-files">Beware Python's pyc files</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-09-19T17:53:00+01:00">2013-09-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenvwrapper-in">Explaining Python virtualenvwrapper (in a couple of minutes)</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-05-10T11:05:00+01:00">2014-05-10</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-use-mock-in-python-to-mock">How to use mock in Python to mock methods on objects</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-05-09T21:29:00+01:00">2014-05-09</time></span> <a href="http://www.stevenmaude.co.uk/posts/beware-pythons-pyc-files">Beware Python's pyc files</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-04-19T15:57:00+01:00">2014-04-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/us-pycon-2014-talks">US PyCon 2014 talks</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-11-27T20:24:00+00:00">2013-11-27</time></span> <a href="http://www.stevenmaude.co.uk/posts/installing-bokeh-on-ubuntu-1204-lts">Installing Bokeh on Ubuntu 12.04 LTS</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-09-30T18:57:00+01:00">2013-09-30</time></span> <a href="http://www.stevenmaude.co.uk/posts/installing-matplotlib-in-virtualenv">Installing matplotlib in a virtualenv</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-06-09T13:43:00+01:00">2013-06-09</time></span> <a href="http://www.stevenmaude.co.uk/posts/installing-python-modules-on-windows">Installing Python modules on Windows: unable to find vcvarsall.bat</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-07-06T18:51:00+01:00">2013-07-06</time></span> <a href="http://www.stevenmaude.co.uk/posts/scraping-natures-job-website">Scraping Nature's job website</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-04-19T15:57:00+01:00">2014-04-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/us-pycon-2014-talks">US PyCon 2014 talks</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-19T17:53:00+01:00">2013-09-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenvwrapper-in">Explaining Python virtualenvwrapper (in a couple of minutes)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-07-17T19:32:00+01:00">2013-07-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/uses-for-a-raspberry-pi-part-2">Uses for a Raspberry Pi (part 2)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-07-06T18:51:00+01:00">2013-07-06</time></span> <a href="http://www.stevenmaude.co.uk/posts/scraping-natures-job-website">Scraping Nature's job website</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-06-09T13:43:00+01:00">2013-06-09</time></span> <a href="http://www.stevenmaude.co.uk/posts/installing-python-modules-on-windows">Installing Python modules on Windows: unable to find vcvarsall.bat</a></p>
                     </div>
                 </div>
             </div>
@@ -2061,8 +2061,8 @@ stevenmaude.co.uk            </a>
                 <div id="collapse-raspberry" class="panel-collapse collapse">
                     <div class="panel-body">
                         <p><span class="categories-timestamp"><time datetime="2014-01-31T12:59:00+00:00">2014-01-31</time></span> <a href="http://www.stevenmaude.co.uk/posts/ensuring-scheduled-cron-jobs-are-run">Ensuring scheduled cron jobs are run using anacron</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-07-10T21:21:00+01:00">2013-07-10</time></span> <a href="http://www.stevenmaude.co.uk/posts/uses-for-a-raspberry-pi-part-1">Uses for a Raspberry Pi (part 1)</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-07-17T19:32:00+01:00">2013-07-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/uses-for-a-raspberry-pi-part-2">Uses for a Raspberry Pi (part 2)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-07-10T21:21:00+01:00">2013-07-10</time></span> <a href="http://www.stevenmaude.co.uk/posts/uses-for-a-raspberry-pi-part-1">Uses for a Raspberry Pi (part 1)</a></p>
                     </div>
                 </div>
             </div>
@@ -2123,8 +2123,8 @@ stevenmaude.co.uk            </a>
                 <div id="collapse-research" class="panel-collapse collapse">
                     <div class="panel-body">
                         <p><span class="categories-timestamp"><time datetime="2014-06-22T21:47:00+01:00">2014-06-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/chatting-about-data-science-careers">Chatting about data science careers</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-05-25T18:32:00+01:00">2013-05-25</time></span> <a href="http://www.stevenmaude.co.uk/posts/close-to-edit-what-researchers-can">Close to the edit: what researchers can learn from journal editing</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-11-03T13:23:00+00:00">2013-11-03</time></span> <a href="http://www.stevenmaude.co.uk/posts/differences-between-working-in">Differences between working in university research and a tech startup</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-05-25T18:32:00+01:00">2013-05-25</time></span> <a href="http://www.stevenmaude.co.uk/posts/close-to-edit-what-researchers-can">Close to the edit: what researchers can learn from journal editing</a></p>
                     </div>
                 </div>
             </div>
@@ -2232,10 +2232,10 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-science" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2014-01-14T18:35:00+00:00">2014-01-14</time></span> <a href="http://www.stevenmaude.co.uk/posts/book-review-data-science-for-business">Book review: "Data Science for Business"</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-06-22T21:47:00+01:00">2014-06-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/chatting-about-data-science-careers">Chatting about data science careers</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-06-24T21:05:00+01:00">2013-06-24</time></span> <a href="http://www.stevenmaude.co.uk/posts/courseras-introduction-to-data-science">Coursera's Introduction to Data Science course</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-01-14T18:35:00+00:00">2014-01-14</time></span> <a href="http://www.stevenmaude.co.uk/posts/book-review-data-science-for-business">Book review: "Data Science for Business"</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-07-02T17:22:00+01:00">2013-07-02</time></span> <a href="http://www.stevenmaude.co.uk/posts/types-of-data-scientist">Types of data scientist</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-06-24T21:05:00+01:00">2013-06-24</time></span> <a href="http://www.stevenmaude.co.uk/posts/courseras-introduction-to-data-science">Coursera's Introduction to Data Science course</a></p>
                     </div>
                 </div>
             </div>
@@ -2259,8 +2259,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-scraping" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-07-06T18:51:00+01:00">2013-07-06</time></span> <a href="http://www.stevenmaude.co.uk/posts/scraping-natures-job-website">Scraping Nature's job website</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-04-19T15:57:00+01:00">2014-04-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/us-pycon-2014-talks">US PyCon 2014 talks</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-07-06T18:51:00+01:00">2013-07-06</time></span> <a href="http://www.stevenmaude.co.uk/posts/scraping-natures-job-website">Scraping Nature's job website</a></p>
                     </div>
                 </div>
             </div>
@@ -2429,8 +2429,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-ssh" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-09-07T11:48:00+01:00">2013-09-07</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-access-github-over-ssh-on-ubuntu">How to access GitHub over SSH on Ubuntu</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-10-08T19:33:00+01:00">2013-10-08</time></span> <a href="http://www.stevenmaude.co.uk/posts/working-with-multiple-ssh-keys-setting">Working with multiple SSH keys: setting up git over SSH with GitHub and Bitbucket</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-07T11:48:00+01:00">2013-09-07</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-access-github-over-ssh-on-ubuntu">How to access GitHub over SSH on Ubuntu</a></p>
                     </div>
                 </div>
             </div>
@@ -2611,8 +2611,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-truecrypt" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-09-28T17:03:00+01:00">2013-09-28</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-secure-your-storage-and-backup">How to secure your storage and backup drives on Windows and Linux</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
                     </div>
                 </div>
             </div>
@@ -2636,14 +2636,14 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-ubuntu" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-09-19T17:53:00+01:00">2013-09-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenvwrapper-in">Explaining Python virtualenvwrapper (in a couple of minutes)</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-09-22T21:49:00+01:00">2013-09-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/fixing-chromium-on-ubuntu-video">Fixing Chromium on Ubuntu video playback issues (no video, black screen)</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-11-20T18:51:00+00:00">2013-11-20</time></span> <a href="http://www.stevenmaude.co.uk/posts/horrible-wireless-network-pings-in">Horrible wireless network pings in Ubuntu and how to fix them</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-09-07T11:48:00+01:00">2013-09-07</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-access-github-over-ssh-on-ubuntu">How to access GitHub over SSH on Ubuntu</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-07-29T23:15:00+01:00">2014-07-29</time></span> <a href="http://www.stevenmaude.co.uk/posts/my-wifis-connected-but-theres-no">My wifi's connected, but there's no internet...? (Intel Centrino versus Ubuntu)</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-12-24T00:04:00+00:00">2013-12-24</time></span> <a href="http://www.stevenmaude.co.uk/posts/some-spring-winter-ubuntu-cleaning">Some <s>spring</s> winter Ubuntu cleaning</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-11-20T18:51:00+00:00">2013-11-20</time></span> <a href="http://www.stevenmaude.co.uk/posts/horrible-wireless-network-pings-in">Horrible wireless network pings in Ubuntu and how to fix them</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-22T21:49:00+01:00">2013-09-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/fixing-chromium-on-ubuntu-video">Fixing Chromium on Ubuntu video playback issues (no video, black screen)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-19T17:53:00+01:00">2013-09-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenvwrapper-in">Explaining Python virtualenvwrapper (in a couple of minutes)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-07T11:48:00+01:00">2013-09-07</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-access-github-over-ssh-on-ubuntu">How to access GitHub over SSH on Ubuntu</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
                     </div>
                 </div>
             </div>
@@ -2765,9 +2765,9 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-virtualenv" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-09-19T17:53:00+01:00">2013-09-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenvwrapper-in">Explaining Python virtualenvwrapper (in a couple of minutes)</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-09-30T18:57:00+01:00">2013-09-30</time></span> <a href="http://www.stevenmaude.co.uk/posts/installing-matplotlib-in-virtualenv">Installing matplotlib in a virtualenv</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-09-19T17:53:00+01:00">2013-09-19</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenvwrapper-in">Explaining Python virtualenvwrapper (in a couple of minutes)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-08-22T20:31:00+01:00">2013-08-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/explaining-python-virtualenv-in-under">Explaining Python virtualenv (in under two minutes)</a></p>
                     </div>
                 </div>
             </div>
@@ -2803,8 +2803,8 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-wifi" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-11-20T18:51:00+00:00">2013-11-20</time></span> <a href="http://www.stevenmaude.co.uk/posts/horrible-wireless-network-pings-in">Horrible wireless network pings in Ubuntu and how to fix them</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-07-29T23:15:00+01:00">2014-07-29</time></span> <a href="http://www.stevenmaude.co.uk/posts/my-wifis-connected-but-theres-no">My wifi's connected, but there's no internet...? (Intel Centrino versus Ubuntu)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-11-20T18:51:00+00:00">2013-11-20</time></span> <a href="http://www.stevenmaude.co.uk/posts/horrible-wireless-network-pings-in">Horrible wireless network pings in Ubuntu and how to fix them</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-07-10T21:21:00+01:00">2013-07-10</time></span> <a href="http://www.stevenmaude.co.uk/posts/uses-for-a-raspberry-pi-part-1">Uses for a Raspberry Pi (part 1)</a></p>
                     </div>
                 </div>
@@ -2817,11 +2817,11 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-windows" class="panel-collapse collapse">
                     <div class="panel-body">
+                        <p><span class="categories-timestamp"><time datetime="2014-01-12T15:11:00+00:00">2014-01-12</time></span> <a href="http://www.stevenmaude.co.uk/posts/making-aero-theme-settings-stick-in">Making Aero theme settings stick in Windows (resetting on log off)</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2014-01-11T23:51:00+00:00">2014-01-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-delete-directories-that-respawn">How to delete directories that respawn in Windows 7</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-12-11T10:36:00+00:00">2013-12-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/windows-update-locking-up-on-xp-when">Windows Update locking up on XP when checking for updates: fixing the svchost.exe CPU usage problem</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-09-17T18:48:00+01:00">2013-09-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/a-beginners-guide-to-os-encryption-dual">A beginner's guide to OS encryption: dual booting and encrypting Windows and Ubuntu</a></p>
                         <p><span class="categories-timestamp"><time datetime="2013-05-17T12:10:00+01:00">2013-05-17</time></span> <a href="http://www.stevenmaude.co.uk/posts/firefox-21-annoyances">Firefox 21 annoyances</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-01-11T23:51:00+00:00">2014-01-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/how-to-delete-directories-that-respawn">How to delete directories that respawn in Windows 7</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2014-01-12T15:11:00+00:00">2014-01-12</time></span> <a href="http://www.stevenmaude.co.uk/posts/making-aero-theme-settings-stick-in">Making Aero theme settings stick in Windows (resetting on log off)</a></p>
-                        <p><span class="categories-timestamp"><time datetime="2013-12-11T10:36:00+00:00">2013-12-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/windows-update-locking-up-on-xp-when">Windows Update locking up on XP when checking for updates: fixing the svchost.exe CPU usage problem</a></p>
                     </div>
                 </div>
             </div>
@@ -2846,9 +2846,9 @@ stevenmaude.co.uk            </a>
                 </div>
                 <div id="collapse-wordpress" class="panel-collapse collapse">
                     <div class="panel-body">
-                        <p><span class="categories-timestamp"><time datetime="2013-05-11T12:55:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/blogger-versus-wordpress">Blogger versus WordPress</a></p>
                         <p><span class="categories-timestamp"><time datetime="2015-06-06T14:46:00+01:00">2015-06-06</time></span> <a href="http://www.stevenmaude.co.uk/posts/blogger-versus-wordpress-revisited">Blogger versus Wordpress revisited</a></p>
                         <p><span class="categories-timestamp"><time datetime="2014-03-22T14:55:00+00:00">2014-03-22</time></span> <a href="http://www.stevenmaude.co.uk/posts/full-circle">Full circle</a></p>
+                        <p><span class="categories-timestamp"><time datetime="2013-05-11T12:55:00+01:00">2013-05-11</time></span> <a href="http://www.stevenmaude.co.uk/posts/blogger-versus-wordpress">Blogger versus WordPress</a></p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Seems to affect tag page generation; think this puts articles in
the reverse chronological order of publication. Previously, I think
this ordering was alphabetical.
