### PR TITLE
Generate output after using new Pelican venv

### DIFF
--- a/2013/05/blogger-versus-wordpress.html
+++ b/2013/05/blogger-versus-wordpress.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/blogger-versus-wordpress"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/blogger-versus-wordpress" />
 </head></html>

--- a/2013/05/close-to-edit-what-researchers-can.html
+++ b/2013/05/close-to-edit-what-researchers-can.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/close-to-edit-what-researchers-can"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/close-to-edit-what-researchers-can" />
 </head></html>

--- a/2013/05/converting-pdfs-to-series-of-images.html
+++ b/2013/05/converting-pdfs-to-series-of-images.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/converting-pdfs-to-series-of-images"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/converting-pdfs-to-series-of-images" />
 </head></html>

--- a/2013/05/firefox-21-annoyances.html
+++ b/2013/05/firefox-21-annoyances.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/firefox-21-annoyances"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/firefox-21-annoyances" />
 </head></html>

--- a/2013/05/job-advertisements.html
+++ b/2013/05/job-advertisements.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/job-advertisements"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/job-advertisements" />
 </head></html>

--- a/2013/05/patching-android-roms-for-pdroid-using.html
+++ b/2013/05/patching-android-roms-for-pdroid-using.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/patching-android-roms-for-pdroid-using"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/patching-android-roms-for-pdroid-using" />
 </head></html>

--- a/2013/05/uninstalling-gotomeeting.html
+++ b/2013/05/uninstalling-gotomeeting.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/uninstalling-gotomeeting"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/uninstalling-gotomeeting" />
 </head></html>

--- a/2013/06/courseras-introduction-to-data-science.html
+++ b/2013/06/courseras-introduction-to-data-science.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/courseras-introduction-to-data-science"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/courseras-introduction-to-data-science" />
 </head></html>

--- a/2013/06/installing-python-modules-on-windows.html
+++ b/2013/06/installing-python-modules-on-windows.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/installing-python-modules-on-windows"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/installing-python-modules-on-windows" />
 </head></html>

--- a/2013/06/leaky-phone-apps.html
+++ b/2013/06/leaky-phone-apps.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/leaky-phone-apps"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/leaky-phone-apps" />
 </head></html>

--- a/2013/07/migrating-email-from-pop-to-imap.html
+++ b/2013/07/migrating-email-from-pop-to-imap.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/migrating-email-from-pop-to-imap"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/migrating-email-from-pop-to-imap" />
 </head></html>

--- a/2013/07/scraping-natures-job-website.html
+++ b/2013/07/scraping-natures-job-website.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/scraping-natures-job-website"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/scraping-natures-job-website" />
 </head></html>

--- a/2013/07/types-of-data-scientist.html
+++ b/2013/07/types-of-data-scientist.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/types-of-data-scientist"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/types-of-data-scientist" />
 </head></html>

--- a/2013/07/uses-for-a-raspberry-pi-part-1.html
+++ b/2013/07/uses-for-a-raspberry-pi-part-1.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/uses-for-a-raspberry-pi-part-1"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/uses-for-a-raspberry-pi-part-1" />
 </head></html>

--- a/2013/07/uses-for-a-raspberry-pi-part-2.html
+++ b/2013/07/uses-for-a-raspberry-pi-part-2.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/uses-for-a-raspberry-pi-part-2"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/uses-for-a-raspberry-pi-part-2" />
 </head></html>

--- a/2013/08/dariks-boot-and-nuke-unrecognized.html
+++ b/2013/08/dariks-boot-and-nuke-unrecognized.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/dariks-boot-and-nuke-unrecognized"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/dariks-boot-and-nuke-unrecognized" />
 </head></html>

--- a/2013/08/explaining-python-virtualenv-in-under.html
+++ b/2013/08/explaining-python-virtualenv-in-under.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/explaining-python-virtualenv-in-under"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/explaining-python-virtualenv-in-under" />
 </head></html>

--- a/2013/08/how-universities-can-help-develop.html
+++ b/2013/08/how-universities-can-help-develop.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/how-universities-can-help-develop"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/how-universities-can-help-develop" />
 </head></html>

--- a/2013/09/a-beginners-guide-to-os-encryption-dual.html
+++ b/2013/09/a-beginners-guide-to-os-encryption-dual.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/a-beginners-guide-to-os-encryption-dual"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/a-beginners-guide-to-os-encryption-dual" />
 </head></html>

--- a/2013/09/explaining-python-virtualenvwrapper-in.html
+++ b/2013/09/explaining-python-virtualenvwrapper-in.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/explaining-python-virtualenvwrapper-in"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/explaining-python-virtualenvwrapper-in" />
 </head></html>

--- a/2013/09/fixing-chromium-on-ubuntu-video.html
+++ b/2013/09/fixing-chromium-on-ubuntu-video.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/fixing-chromium-on-ubuntu-video"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/fixing-chromium-on-ubuntu-video" />
 </head></html>

--- a/2013/09/how-to-access-github-over-ssh-on-ubuntu.html
+++ b/2013/09/how-to-access-github-over-ssh-on-ubuntu.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/how-to-access-github-over-ssh-on-ubuntu"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/how-to-access-github-over-ssh-on-ubuntu" />
 </head></html>

--- a/2013/09/how-to-secure-your-storage-and-backup.html
+++ b/2013/09/how-to-secure-your-storage-and-backup.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/how-to-secure-your-storage-and-backup"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/how-to-secure-your-storage-and-backup" />
 </head></html>

--- a/2013/09/installing-matplotlib-in-virtualenv.html
+++ b/2013/09/installing-matplotlib-in-virtualenv.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/installing-matplotlib-in-virtualenv"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/installing-matplotlib-in-virtualenv" />
 </head></html>

--- a/2013/10/odd-behaviour-of-bitlocker-or-maybe-my.html
+++ b/2013/10/odd-behaviour-of-bitlocker-or-maybe-my.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/odd-behaviour-of-bitlocker-or-maybe-my"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/odd-behaviour-of-bitlocker-or-maybe-my" />
 </head></html>

--- a/2013/10/working-with-multiple-ssh-keys-setting.html
+++ b/2013/10/working-with-multiple-ssh-keys-setting.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/working-with-multiple-ssh-keys-setting"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/working-with-multiple-ssh-keys-setting" />
 </head></html>

--- a/2013/11/differences-between-working-in.html
+++ b/2013/11/differences-between-working-in.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/differences-between-working-in"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/differences-between-working-in" />
 </head></html>

--- a/2013/11/horrible-wireless-network-pings-in.html
+++ b/2013/11/horrible-wireless-network-pings-in.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/horrible-wireless-network-pings-in"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/horrible-wireless-network-pings-in" />
 </head></html>

--- a/2013/11/installling-bokeh-on-ubuntu-1204-lts.html
+++ b/2013/11/installling-bokeh-on-ubuntu-1204-lts.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/installing-bokeh-on-ubuntu-1204-lts"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/installing-bokeh-on-ubuntu-1204-lts" />
 </head></html>

--- a/2013/11/its-not-often-that-i-think-of-technical.html
+++ b/2013/11/its-not-often-that-i-think-of-technical.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/its-not-often-that-i-think-of-technical"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/its-not-often-that-i-think-of-technical" />
 </head></html>

--- a/2013/12/some-spring-winter-ubuntu-cleaning.html
+++ b/2013/12/some-spring-winter-ubuntu-cleaning.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/some-spring-winter-ubuntu-cleaning"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/some-spring-winter-ubuntu-cleaning" />
 </head></html>

--- a/2013/12/things-ive-learned-from-building-and.html
+++ b/2013/12/things-ive-learned-from-building-and.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/things-ive-learned-from-building-and"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/things-ive-learned-from-building-and" />
 </head></html>

--- a/2013/12/windows-update-locking-up-on-xp-when.html
+++ b/2013/12/windows-update-locking-up-on-xp-when.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/windows-update-locking-up-on-xp-when"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/windows-update-locking-up-on-xp-when" />
 </head></html>

--- a/2014/01/beatmatching-five-reasons-why-digital.html
+++ b/2014/01/beatmatching-five-reasons-why-digital.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/beatmatching-five-reasons-why-digital"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/beatmatching-five-reasons-why-digital" />
 </head></html>

--- a/2014/01/book-review-data-science-for-business.html
+++ b/2014/01/book-review-data-science-for-business.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/book-review-data-science-for-business"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/book-review-data-science-for-business" />
 </head></html>

--- a/2014/01/ensuring-scheduled-cron-jobs-are-run.html
+++ b/2014/01/ensuring-scheduled-cron-jobs-are-run.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/ensuring-scheduled-cron-jobs-are-run"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/ensuring-scheduled-cron-jobs-are-run" />
 </head></html>

--- a/2014/01/fixing-no-ink-levels-being-displayed-in.html
+++ b/2014/01/fixing-no-ink-levels-being-displayed-in.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/fixing-no-ink-levels-being-displayed-in"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/fixing-no-ink-levels-being-displayed-in" />
 </head></html>

--- a/2014/01/how-to-delete-directories-that-respawn.html
+++ b/2014/01/how-to-delete-directories-that-respawn.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/how-to-delete-directories-that-respawn"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/how-to-delete-directories-that-respawn" />
 </head></html>

--- a/2014/01/making-aero-theme-settings-stick-in.html
+++ b/2014/01/making-aero-theme-settings-stick-in.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/making-aero-theme-settings-stick-in"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/making-aero-theme-settings-stick-in" />
 </head></html>

--- a/2014/01/securely-erasing-ssd-drives.html
+++ b/2014/01/securely-erasing-ssd-drives.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/securely-erasing-ssd-drives"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/securely-erasing-ssd-drives" />
 </head></html>

--- a/2014/03/full-circle.html
+++ b/2014/03/full-circle.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/full-circle"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/full-circle" />
 </head></html>

--- a/2014/03/how-to-give-back-to-open-source-software.html
+++ b/2014/03/how-to-give-back-to-open-source-software.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/how-to-give-back-to-open-source-software"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/how-to-give-back-to-open-source-software" />
 </head></html>

--- a/2014/03/phone-upgrades-and-privacy-downgrades.html
+++ b/2014/03/phone-upgrades-and-privacy-downgrades.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/phone-upgrades-and-privacy-downgrades"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/phone-upgrades-and-privacy-downgrades" />
 </head></html>

--- a/2014/03/the-death-of-desktop-pc.html
+++ b/2014/03/the-death-of-desktop-pc.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/the-death-of-desktop-pc"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/the-death-of-desktop-pc" />
 </head></html>

--- a/2014/04/android-device-encryption-is-mostly-good.html
+++ b/2014/04/android-device-encryption-is-mostly-good.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/android-device-encryption-is-mostly-good"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/android-device-encryption-is-mostly-good" />
 </head></html>

--- a/2014/04/making-midi-keyboard-modulation-wheel.html
+++ b/2014/04/making-midi-keyboard-modulation-wheel.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/making-midi-keyboard-modulation-wheel"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/making-midi-keyboard-modulation-wheel" />
 </head></html>

--- a/2014/04/rockbox-ipod-nano-2g-and-inverted-audio.html
+++ b/2014/04/rockbox-ipod-nano-2g-and-inverted-audio.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/rockbox-ipod-nano-2g-and-inverted-audio"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/rockbox-ipod-nano-2g-and-inverted-audio" />
 </head></html>

--- a/2014/04/us-pycon-2014-talks.html
+++ b/2014/04/us-pycon-2014-talks.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/us-pycon-2014-talks"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/us-pycon-2014-talks" />
 </head></html>

--- a/2014/05/52-weeks-52-posts.html
+++ b/2014/05/52-weeks-52-posts.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/52-weeks-52-posts"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/52-weeks-52-posts" />
 </head></html>

--- a/2014/05/beware-pythons-pyc-files.html
+++ b/2014/05/beware-pythons-pyc-files.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/beware-pythons-pyc-files"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/beware-pythons-pyc-files" />
 </head></html>

--- a/2014/05/heartbleed-ill-communication.html
+++ b/2014/05/heartbleed-ill-communication.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/heartbleed-ill-communication"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/heartbleed-ill-communication" />
 </head></html>

--- a/2014/05/how-to-use-mock-in-python-to-mock.html
+++ b/2014/05/how-to-use-mock-in-python-to-mock.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/how-to-use-mock-in-python-to-mock"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/how-to-use-mock-in-python-to-mock" />
 </head></html>

--- a/2014/06/chatting-about-data-science-careers.html
+++ b/2014/06/chatting-about-data-science-careers.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/chatting-about-data-science-careers"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/chatting-about-data-science-careers" />
 </head></html>

--- a/2014/07/arduous-lessons-in-python-why-main-is.html
+++ b/2014/07/arduous-lessons-in-python-why-main-is.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/arduous-lessons-in-python-why-main-is"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/arduous-lessons-in-python-why-main-is" />
 </head></html>

--- a/2014/07/my-wifis-connected-but-theres-no.html
+++ b/2014/07/my-wifis-connected-but-theres-no.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/my-wifis-connected-but-theres-no"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/my-wifis-connected-but-theres-no" />
 </head></html>

--- a/2014/08/updating-and-rooting-moto-g.html
+++ b/2014/08/updating-and-rooting-moto-g.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/updating-and-rooting-moto-g"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/updating-and-rooting-moto-g" />
 </head></html>

--- a/2014/09/taking-control-of-chromium-and-chrome.html
+++ b/2014/09/taking-control-of-chromium-and-chrome.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/posts/taking-control-of-chromium-and-chrome"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/posts/taking-control-of-chromium-and-chrome" />
 </head></html>

--- a/archives.html
+++ b/archives.html
@@ -814,18 +814,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude.html
+++ b/author/steven-maude.html
@@ -337,18 +337,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude2.html
+++ b/author/steven-maude2.html
@@ -378,18 +378,18 @@ generators.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude3.html
+++ b/author/steven-maude3.html
@@ -419,18 +419,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude4.html
+++ b/author/steven-maude4.html
@@ -447,18 +447,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude5.html
+++ b/author/steven-maude5.html
@@ -463,18 +463,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude6.html
+++ b/author/steven-maude6.html
@@ -467,18 +467,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude7.html
+++ b/author/steven-maude7.html
@@ -463,18 +463,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude8.html
+++ b/author/steven-maude8.html
@@ -350,18 +350,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/authors.html
+++ b/authors.html
@@ -107,18 +107,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/categories.html
+++ b/categories.html
@@ -233,18 +233,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/2013.html
+++ b/category/2013.html
@@ -484,18 +484,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20132.html
+++ b/category/20132.html
@@ -468,18 +468,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20133.html
+++ b/category/20133.html
@@ -434,18 +434,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20134.html
+++ b/category/20134.html
@@ -198,18 +198,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/2014.html
+++ b/category/2014.html
@@ -430,18 +430,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20142.html
+++ b/category/20142.html
@@ -444,18 +444,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20143.html
+++ b/category/20143.html
@@ -239,18 +239,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/2015.html
+++ b/category/2015.html
@@ -328,18 +328,18 @@ generators.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/2016.html
+++ b/category/2016.html
@@ -338,18 +338,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20162.html
+++ b/category/20162.html
@@ -186,18 +186,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/feeds/all.atom.xml
+++ b/feeds/all.atom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom"><title>stevenmaude.co.uk</title><link href="http://www.stevenmaude.co.uk/" rel="alternate"></link><link href="http://www.stevenmaude.co.uk/feeds/all.atom.xml" rel="self"></link><id>http://www.stevenmaude.co.uk/</id><updated>2016-11-22T13:54:00+00:00</updated><entry><title>Securely erasing frozen hard disks with hdparm</title><link href="http://www.stevenmaude.co.uk/posts/securely-erasing-frozen-hard-disks-with-hdparm" rel="alternate"></link><updated>2016-11-22T13:54:00+00:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-11-22:posts/securely-erasing-frozen-hard-disks-with-hdparm</id><summary type="html">&lt;p&gt;Yesterday I was trying to erase a hard drive before I used it for a new
+<feed xmlns="http://www.w3.org/2005/Atom"><title>stevenmaude.co.uk</title><link href="http://www.stevenmaude.co.uk/" rel="alternate"></link><link href="http://www.stevenmaude.co.uk/feeds/all.atom.xml" rel="self"></link><id>http://www.stevenmaude.co.uk/</id><updated>2016-11-22T13:54:00+00:00</updated><entry><title>Securely erasing frozen hard disks with hdparm</title><link href="http://www.stevenmaude.co.uk/posts/securely-erasing-frozen-hard-disks-with-hdparm" rel="alternate"></link><published>2016-11-22T13:54:00+00:00</published><updated>2016-11-22T13:54:00+00:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-11-22:posts/securely-erasing-frozen-hard-disks-with-hdparm</id><summary type="html">&lt;p&gt;Yesterday I was trying to erase a hard drive before I used it for a new
 install. It may well have never been used, but I couldn't remember and,
 for the sake of a few minutes, it seemed sensible to do so first.&lt;/p&gt;
 &lt;p&gt;The best way to erase, especially if the drive is a solid state drive,
@@ -22,7 +22,7 @@ accidentally type the wrong thing that you won't erase a drive that you
 didn't intend to.&lt;/p&gt;
 &lt;p&gt;Next, you need to get the drive's name. Open a terminal by pressing
 Ctrl+Alt+T.&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;sudo lshw -class disk
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;sudo lshw -class disk
 &lt;/pre&gt;&lt;/div&gt;
 
 
@@ -36,10 +36,10 @@ advises it due to problems with certain PCs, and it only takes one extra
 command. Note that the "foo" password below can be replaced by something
 of your choice, but it doesn't really matter; when the drive is erased,
 the password should be removed.&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span class="nv"&gt;$ &lt;/span&gt;sudo hdparm --user-master u --security-set-pass foo /dev/sdX
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;$ sudo hdparm --user-master u --security-set-pass foo /dev/sdX
 security_password: &lt;span class="s2"&gt;&amp;quot;foo&amp;quot;&lt;/span&gt;
 /dev/sdX:
- Issuing SECURITY_SET_PASS &lt;span class="nb"&gt;command&lt;/span&gt;, &lt;span class="nv"&gt;password&lt;/span&gt;&lt;span class="o"&gt;=&lt;/span&gt;&lt;span class="s2"&gt;&amp;quot;foo&amp;quot;&lt;/span&gt;, &lt;span class="nv"&gt;user&lt;/span&gt;&lt;span class="o"&gt;=&lt;/span&gt;user, &lt;span class="nv"&gt;mode&lt;/span&gt;&lt;span class="o"&gt;=&lt;/span&gt;high
+ Issuing SECURITY_SET_PASS command, &lt;span class="nv"&gt;password&lt;/span&gt;&lt;span class="o"&gt;=&lt;/span&gt;&lt;span class="s2"&gt;&amp;quot;foo&amp;quot;&lt;/span&gt;, &lt;span class="nv"&gt;user&lt;/span&gt;&lt;span class="o"&gt;=&lt;/span&gt;user, &lt;span class="nv"&gt;mode&lt;/span&gt;&lt;span class="o"&gt;=&lt;/span&gt;high
 SECURITY_SET_PASS: Input/output error
 &lt;/pre&gt;&lt;/div&gt;
 
@@ -49,7 +49,7 @@ SECURITY_SET_PASS: Input/output error
 You might expect it if the drive has a password set already, but in this
 case I couldn't recall doing that. If that's the same for you, it could
 be a simple fix.  First, check the drive's current status via:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span class="nv"&gt;$ &lt;/span&gt;sudo hdparm -I /dev/sdX
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;$ sudo hdparm -I /dev/sdX
 &lt;/pre&gt;&lt;/div&gt;
 
 
@@ -70,13 +70,13 @@ opposed to "not enabled".&lt;/p&gt;
 &lt;p&gt;You can now proceed with the erase. If your drive's &lt;code&gt;hdparm&lt;/code&gt; output
 states &lt;code&gt;supported: enhanced erase&lt;/code&gt;, you could replace the
 &lt;code&gt;--security-erase&lt;/code&gt; below with &lt;code&gt;--security-erase-enhanced&lt;/code&gt;:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span class="nv"&gt;$ &lt;/span&gt;sudo &lt;span class="nb"&gt;time &lt;/span&gt;hdparm --user-master u --security-erase foo /dev/sdX
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;$ sudo &lt;span class="nb"&gt;time&lt;/span&gt; hdparm --user-master u --security-erase foo /dev/sdX
 &lt;/pre&gt;&lt;/div&gt;
 
 
 &lt;p&gt;After the erase, the password should be removed, and running the &lt;code&gt;hdparm
 -I&lt;/code&gt; command one final time should show that the password is "not
-enabled".&lt;/p&gt;</summary><category term="hdparm"></category><category term="erase"></category></entry><entry><title>Collecting disposable email with go-mailin8</title><link href="http://www.stevenmaude.co.uk/posts/collecting-disposable-email-with-go-mailin8" rel="alternate"></link><updated>2016-11-12T21:47:00+00:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-11-12:posts/collecting-disposable-email-with-go-mailin8</id><summary type="html">&lt;p&gt;&lt;a href="https://github.com/StevenMaude/go-mailin8"&gt;go-mailin8&lt;/a&gt; is a command
+enabled".&lt;/p&gt;</summary><category term="hdparm"></category><category term="erase"></category></entry><entry><title>Collecting disposable email with go-mailin8</title><link href="http://www.stevenmaude.co.uk/posts/collecting-disposable-email-with-go-mailin8" rel="alternate"></link><published>2016-11-12T21:47:00+00:00</published><updated>2016-11-12T21:47:00+00:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-11-12:posts/collecting-disposable-email-with-go-mailin8</id><summary type="html">&lt;p&gt;&lt;a href="https://github.com/StevenMaude/go-mailin8"&gt;go-mailin8&lt;/a&gt; is a command
 line utility I've created to get the most recent message from a
 Mailinator email inbox.&lt;/p&gt;
 &lt;h1&gt;What's Mailinator?&lt;/h1&gt;
@@ -100,7 +100,7 @@ address, loading the inbox page, and clicking the mail to display it and
 then finally copying the activation or download URL I'm looking for.&lt;/p&gt;
 &lt;p&gt;Much easier if I can just run a command line program that just takes the
 local-part of the mailbox name (the part before the @):&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;./go-mailin8 &amp;lt;&lt;span class="nb"&gt;local&lt;/span&gt;-part&amp;gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;./go-mailin8 &amp;lt;local-part&amp;gt;
 &lt;/pre&gt;&lt;/div&gt;
 
 
@@ -118,7 +118,7 @@ is compiled. Much simpler than telling someone to first install Python
 and then the packages that they need. (I realise that the target
 audience of such a tool are probably more than capable of doing so, but
 this reduces the barrier for someone to get the program running on their
-computer nonetheless.)&lt;/p&gt;</summary><category term="golang"></category><category term="Mailinator"></category><category term="email"></category></entry><entry><title>Archiving a WordPress site with wget and hosting for free</title><link href="http://www.stevenmaude.co.uk/posts/archiving-a-wordpress-site-with-wget-and-hosting-for-free" rel="alternate"></link><updated>2016-09-21T23:54:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-09-21:posts/archiving-a-wordpress-site-with-wget-and-hosting-for-free</id><summary type="html">&lt;p&gt;After what seems quite a long time from when the idea was first mentioned to
+computer nonetheless.)&lt;/p&gt;</summary><category term="golang"></category><category term="Mailinator"></category><category term="email"></category></entry><entry><title>Archiving a WordPress site with wget and hosting for free</title><link href="http://www.stevenmaude.co.uk/posts/archiving-a-wordpress-site-with-wget-and-hosting-for-free" rel="alternate"></link><published>2016-09-21T23:54:00+01:00</published><updated>2016-09-21T23:54:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-09-21:posts/archiving-a-wordpress-site-with-wget-and-hosting-for-free</id><summary type="html">&lt;p&gt;After what seems quite a long time from when the idea was first mentioned to
 change the name of my employer, it's finally happened, and they've got a &lt;a href="http://sensiblecode.io"&gt;new
 website&lt;/a&gt; and everything. We still have the old company
 mugs, sadly.&lt;/p&gt;
@@ -151,7 +151,7 @@ site archiving, hit a problem and then discover which &lt;code&gt;wget&lt;/code&
 have used to fix it. The upside is that &lt;code&gt;wget&lt;/code&gt; probably does feature the option
 you require.&lt;/p&gt;
 &lt;p&gt;After lots of trial and error, what I ended up with was (deep breath):&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;wget --page-requisites --convert-links --adjust-extension --mirror --span-hosts --domains&lt;span class="o"&gt;=&lt;/span&gt;blog.scraperwiki.com,scraperwiki.com --exclude-domains beta.scraperwiki.com,classic.scraperwiki.com,media.scraperwiki.com,mot.scraperwiki.com,newsreader.scraperwiki.com,premium.scraperwiki.com,status.scraperwiki.com,x.scraperwiki.com scraperwiki.com
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;wget --page-requisites --convert-links --adjust-extension --mirror --span-hosts --domains&lt;span class="o"&gt;=&lt;/span&gt;blog.scraperwiki.com,scraperwiki.com --exclude-domains beta.scraperwiki.com,classic.scraperwiki.com,media.scraperwiki.com,mot.scraperwiki.com,newsreader.scraperwiki.com,premium.scraperwiki.com,status.scraperwiki.com,x.scraperwiki.com scraperwiki.com
 &lt;/pre&gt;&lt;/div&gt;
 
 
@@ -250,7 +250,7 @@ gets correctly requested as a filename with a question mark in it. Not
 particularly clean, but it worked. It may have just been using a recent
 version of &lt;code&gt;wget&lt;/code&gt; that solved this. This was nice as the alternative was
 a horrendous find/replace task using commands like:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;find . -type f -exec grep -Iq . &lt;span class="o"&gt;{}&lt;/span&gt; &lt;span class="se"&gt;\;&lt;/span&gt; -and -exec sed -i
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;find . -type f -exec grep -Iq . &lt;span class="o"&gt;{}&lt;/span&gt; &lt;span class="se"&gt;\;&lt;/span&gt; -and -exec sed -i
 &lt;span class="s1"&gt;&amp;#39;s!wp-content/plugins/jetpack/css/jetpack.css?ver=4.1.1!wp-content/plugins/jetpack/css/jetpack.css!g&amp;#39;&lt;/span&gt;
 &lt;span class="o"&gt;{}&lt;/span&gt; &lt;span class="se"&gt;\;&lt;/span&gt;
 &lt;/pre&gt;&lt;/div&gt;
@@ -337,7 +337,7 @@ issues.&lt;/p&gt;
 installation to run the site and the site's getting hosted
 for free.&lt;/p&gt;
 &lt;p&gt;Good luck if you're tackling the same problem! Hopefully some of the
-tips here might help you with your migration.&lt;/p&gt;</summary><category term="WordPress"></category></entry><entry><title>Stopping Windows from rebooting at the BitLocker boot password prompt</title><link href="http://www.stevenmaude.co.uk/posts/stopping-windows-from-rebooting-at-the-bitlocker-boot-password-prompt" rel="alternate"></link><updated>2016-09-17T23:52:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-09-17:posts/stopping-windows-from-rebooting-at-the-bitlocker-boot-password-prompt</id><summary type="html">&lt;p&gt;Short post, but more noting this for myself more than anything. There
+tips here might help you with your migration.&lt;/p&gt;</summary><category term="WordPress"></category></entry><entry><title>Stopping Windows from rebooting at the BitLocker boot password prompt</title><link href="http://www.stevenmaude.co.uk/posts/stopping-windows-from-rebooting-at-the-bitlocker-boot-password-prompt" rel="alternate"></link><published>2016-09-17T23:52:00+01:00</published><updated>2016-09-17T23:52:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-09-17:posts/stopping-windows-from-rebooting-at-the-bitlocker-boot-password-prompt</id><summary type="html">&lt;p&gt;Short post, but more noting this for myself more than anything. There
 are several times when I've blogged little fixes and they've proven
 handy to have in the future, e.g. when I'm setting up a new PC. Partly
 because I know they're on my blog, and partly because the posts are
@@ -350,12 +350,12 @@ password in time. This is apparently a problem if you have a UEFI install,
 which will be a common configuration these days.&lt;/p&gt;
 &lt;p&gt;Having just tested this simple fix that I saw on &lt;a href="https://social.technet.microsoft.com/Forums/office/en-US/932630c2-ae3d-4cbd-8d79-a492806363ea/windows-81-bitlocker-automatic-shutdown-during-password-prompt?forum=w8itproinstall"&gt;Microsoft's
 forums&lt;/a&gt;:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;bcdedit /set {bootmgr} bootshutdowndisabled 1
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;span class="go"&gt;bcdedit /set {bootmgr} bootshutdowndisabled 1&lt;/span&gt;
 &lt;/pre&gt;&lt;/div&gt;
 
 
 &lt;p&gt;it seems to have resolved the problem; the password prompt will remain on
-indefinitely.&lt;/p&gt;</summary><category term="BitLocker"></category></entry><entry><title>What happens when GitHub decides you're not a human</title><link href="http://www.stevenmaude.co.uk/posts/what-happens-when-github-decides-youre-not-a-human" rel="alternate"></link><updated>2016-09-11T23:47:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-09-11:posts/what-happens-when-github-decides-youre-not-a-human</id><summary type="html">&lt;blockquote&gt;
+indefinitely.&lt;/p&gt;</summary><category term="BitLocker"></category></entry><entry><title>What happens when GitHub decides you're not a human</title><link href="http://www.stevenmaude.co.uk/posts/what-happens-when-github-decides-youre-not-a-human" rel="alternate"></link><published>2016-09-11T23:47:00+01:00</published><updated>2016-09-11T23:47:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-09-11:posts/what-happens-when-github-decides-youre-not-a-human</id><summary type="html">&lt;blockquote&gt;
   &lt;p&gt;Human, human, human, human,&lt;br&gt;
      Human, human, human, human,&lt;br&gt;
      Human, human, human, human,&lt;br&gt;
@@ -520,7 +520,7 @@ realm of DJ tools that work magnificently live.&amp;#160;&lt;a class="footnote-b
   configured.)&amp;#160;&lt;a class="footnote-backref" href="#fnref:3" rev="footnote" title="Jump back to footnote 3 in the text"&gt;&amp;#8617;&lt;/a&gt;&lt;/p&gt;
 &lt;/li&gt;
 &lt;/ol&gt;
-&lt;/div&gt;</summary><category term="GitHub"></category></entry><entry><title>Windows 10 installation impressions</title><link href="http://www.stevenmaude.co.uk/posts/windows-10-installation-impressions" rel="alternate"></link><updated>2016-07-02T23:35:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-07-02:posts/windows-10-installation-impressions</id><summary type="html">&lt;p&gt;Windows 10 is only a free upgrade from Windows 7 or 8.1 until the end of
+&lt;/div&gt;</summary><category term="GitHub"></category></entry><entry><title>Windows 10 installation impressions</title><link href="http://www.stevenmaude.co.uk/posts/windows-10-installation-impressions" rel="alternate"></link><published>2016-07-02T23:35:00+01:00</published><updated>2016-07-02T23:35:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-07-02:posts/windows-10-installation-impressions</id><summary type="html">&lt;p&gt;Windows 10 is only a free upgrade from Windows 7 or 8.1 until the end of
 this month&lt;sup id="fnref:1"&gt;&lt;a class="footnote-ref" href="#fn:1" rel="footnote"&gt;1&lt;/a&gt;&lt;/sup&gt;. If you've hesitated so far, you might be a bit unsure as
 to whether you should switch a system you're satisfied with for a
 potentially less satisfactory one. But, if you want a free upgrade, you
@@ -730,7 +730,7 @@ previous upgrade strategy from XP to 7 was to copy everything over, then
 reinstall whichever extras for that game required it.&amp;#160;&lt;a class="footnote-backref" href="#fnref:3" rev="footnote" title="Jump back to footnote 3 in the text"&gt;&amp;#8617;&lt;/a&gt;&lt;/p&gt;
 &lt;/li&gt;
 &lt;/ol&gt;
-&lt;/div&gt;</summary><category term="Windows"></category><category term="installation"></category></entry><entry><title>Book (and talk) review: Making Music. 74 Creative Strategies for Electronic Music Producers.</title><link href="http://www.stevenmaude.co.uk/posts/book-and-talk-review-making-music-74-creative-strategies-for-electronic-music-producers" rel="alternate"></link><updated>2016-06-26T12:40:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-06-26:posts/book-and-talk-review-making-music-74-creative-strategies-for-electronic-music-producers</id><summary type="html">&lt;p&gt;Last week, I went to Sónar for a second time, and the sunshine and music
+&lt;/div&gt;</summary><category term="Windows"></category><category term="installation"></category></entry><entry><title>Book (and talk) review: Making Music. 74 Creative Strategies for Electronic Music Producers.</title><link href="http://www.stevenmaude.co.uk/posts/book-and-talk-review-making-music-74-creative-strategies-for-electronic-music-producers" rel="alternate"></link><published>2016-06-26T12:40:00+01:00</published><updated>2016-06-26T12:40:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-06-26:posts/book-and-talk-review-making-music-74-creative-strategies-for-electronic-music-producers</id><summary type="html">&lt;p&gt;Last week, I went to Sónar for a second time, and the sunshine and music
 there feels a hazy and distant dream today. Nonetheless, it reminded me
 that I had the bulk of a write-up of one of last year's Sónar+D talks
 sat around for a while. It's still relevant, because of the subject
@@ -897,7 +897,7 @@ reading. It should be stressed that the ideas covered are software,
 hardware and even genre agnostic. There's nothing presented that's
 particularly Ableton specific. It would be a pity if fewer people
 ignored it because of that; it's an enjoyable and enlightening read for
-learners.&lt;/p&gt;</summary><category term="book review"></category><category term="music"></category><category term="production"></category></entry><entry><title>PyPI: releasing frustration</title><link href="http://www.stevenmaude.co.uk/posts/pypi-releasing-frustration" rel="alternate"></link><updated>2016-05-15T12:34:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-05-15:posts/pypi-releasing-frustration</id><summary type="html">&lt;p&gt;A while back I wrote an &lt;a href="https://github.com/StevenMaude/bbc-radio-tracklisting-downloader"&gt;automatic tracklisting downloader for BBC radio
+learners.&lt;/p&gt;</summary><category term="book review"></category><category term="music"></category><category term="production"></category></entry><entry><title>PyPI: releasing frustration</title><link href="http://www.stevenmaude.co.uk/posts/pypi-releasing-frustration" rel="alternate"></link><published>2016-05-15T12:34:00+01:00</published><updated>2016-05-15T12:34:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-05-15:posts/pypi-releasing-frustration</id><summary type="html">&lt;p&gt;A while back I wrote an &lt;a href="https://github.com/StevenMaude/bbc-radio-tracklisting-downloader"&gt;automatic tracklisting downloader for BBC radio
 shows&lt;/a&gt; in
 Python. It's simple to use and it also hooks well into
 &lt;a href="https://github.com/get-iplayer/get_iplayer"&gt;get_iplayer&lt;/a&gt; to retrieve or tag
@@ -950,7 +950,7 @@ message telling you that the version already exists and only then increase the
 version number.&lt;/p&gt;
 &lt;p&gt;The details in the guide show the structure of the &lt;code&gt;.pypirc&lt;/code&gt; configuration.
 However, they don't point out that you can also add the PyPI test site too:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;[distutils]
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;[distutils]
 index-servers=
     pypi
     testpypi
@@ -977,12 +977,12 @@ be released.  &lt;/p&gt;
 which arguments you should use with &lt;code&gt;setup.py&lt;/code&gt; to build your package.&lt;/p&gt;
 &lt;p&gt;If you're trying to build Python wheels, one hiccup is that you likely need the
 &lt;code&gt;wheel&lt;/code&gt; package installed. Otherwise, you may find with a command like:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;python setup.py sdist bdist_wheel
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;python setup.py sdist bdist_wheel
 &lt;/pre&gt;&lt;/div&gt;
 
 
 &lt;p&gt;you get the error:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;error: invalid command &amp;#39;bdist_wheel&amp;#39;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;error: invalid command &amp;#39;bdist_wheel&amp;#39;
 &lt;/pre&gt;&lt;/div&gt;
 
 
@@ -995,7 +995,7 @@ Python 2.7.&lt;/p&gt;
 register the project. Note that you need to specify the repository using &lt;code&gt;-r&lt;/code&gt;
 if you want to use something other than the default, and the name is taken from
 your &lt;code&gt;.pypirc&lt;/code&gt;.&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;Registering bbc-radio-tracklisting-downloader-0.0.1.tar.gz
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;Registering bbc-radio-tracklisting-downloader-0.0.1.tar.gz
 UnicodeDecodeError: &amp;#39;ascii&amp;#39; codec can&amp;#39;t decode byte 0xc2 in position 27:
 ordinal not in range(128)
 &lt;/pre&gt;&lt;/div&gt;
@@ -1006,7 +1006,7 @@ nothing to indicate where the problem lay at all, making it very difficult to
 start fixing it.&lt;/p&gt;
 &lt;p&gt;Switching to Python 3.4 for the upload avoided the Unicode error, but instead
 gave me:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;HTTPError: 401 Client Error: You must login to access this feature for
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;HTTPError: 401 Client Error: You must login to access this feature for
 url: https://pypi.python.org/pypi
 &lt;/pre&gt;&lt;/div&gt;
 
@@ -1040,7 +1040,7 @@ whether read in from a file, or included in full in the &lt;code&gt;setup.py&lt;
 &lt;/ul&gt;
 &lt;p&gt;I went for the latter for simplicity.&lt;/p&gt;
 &lt;p&gt;Using &lt;code&gt;pandoc&lt;/code&gt;, it's pretty simple to convert an existing Markdown file:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;pandoc --from&lt;span class="o"&gt;=&lt;/span&gt;markdown --to&lt;span class="o"&gt;=&lt;/span&gt;rst --output&lt;span class="o"&gt;=&lt;/span&gt;README.rst README.md
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;pandoc --from&lt;span class="o"&gt;=&lt;/span&gt;markdown --to&lt;span class="o"&gt;=&lt;/span&gt;rst --output&lt;span class="o"&gt;=&lt;/span&gt;README.rst README.md
 &lt;/pre&gt;&lt;/div&gt;
 
 
@@ -1051,7 +1051,7 @@ generated. &lt;/p&gt;
 &lt;h3&gt;Uploading&lt;/h3&gt;
 &lt;p&gt;Whew! Back to &lt;code&gt;twine&lt;/code&gt;, and now the project's registered, let's try uploading it
 via:&lt;/p&gt;
-&lt;div class="highlight"&gt;&lt;pre&gt;twine upload dist/* -r testpypi
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;twine upload dist/* -r testpypi
 &lt;/pre&gt;&lt;/div&gt;
 
 
@@ -1091,7 +1091,7 @@ little or no helpful error information was frustrating. Every stumbling block
 encountered is a point where someone could decide that they've had finally
 enough and just give up. In those cases, it's the community's loss. Developers
 who may well have useful packages to contribute may ultimately decide that it's
-not worth the trouble to release on PyPI.&lt;/p&gt;</summary><category term="Python"></category><category term="PyPI"></category></entry><entry><title>Taking web page screenshots smartly with Firefox's Developer Tools</title><link href="http://www.stevenmaude.co.uk/posts/taking-web-page-screenshots-smartly-with-firefoxs-developer-tools" rel="alternate"></link><updated>2016-04-20T20:30:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-04-20:posts/taking-web-page-screenshots-smartly-with-firefoxs-developer-tools</id><summary type="html">&lt;h2&gt;Snap happy&lt;/h2&gt;
+not worth the trouble to release on PyPI.&lt;/p&gt;</summary><category term="Python"></category><category term="PyPI"></category></entry><entry><title>Taking web page screenshots smartly with Firefox's Developer Tools</title><link href="http://www.stevenmaude.co.uk/posts/taking-web-page-screenshots-smartly-with-firefoxs-developer-tools" rel="alternate"></link><published>2016-04-20T20:30:00+01:00</published><updated>2016-04-20T20:30:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-04-20:posts/taking-web-page-screenshots-smartly-with-firefoxs-developer-tools</id><summary type="html">&lt;h2&gt;Snap happy&lt;/h2&gt;
 &lt;p&gt;Firefox has a buried feature in its Developer Tools, which is potentially
 useful even if you're not a developer. If you've never used the Developer
 Tools, just press F12 and you'll see the tools.&lt;/p&gt;
@@ -1128,7 +1128,7 @@ Design mode has its own screenshot tool, near to the resolution menu,
 but this only takes an image of the page visible within the display
 window you've just set, i.e.  it's not necessarily the full page if
 there would still be scroll bars at that actual display resolution
-you've selected.)&lt;/p&gt;</summary><category term="Firefox"></category><category term="screenshot"></category></entry><entry><title>Managing a Bitbucket user's permissions when they've left your team</title><link href="http://www.stevenmaude.co.uk/posts/managing-a-bitbucket-users-permissions-when-theyve-left-your-team" rel="alternate"></link><updated>2016-04-16T01:54:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-04-16:posts/managing-a-bitbucket-users-permissions-when-theyve-left-your-team</id><summary type="html">&lt;h2&gt;Kicking the Bitbucket&lt;/h2&gt;
+you've selected.)&lt;/p&gt;</summary><category term="Firefox"></category><category term="screenshot"></category></entry><entry><title>Managing a Bitbucket user's permissions when they've left your team</title><link href="http://www.stevenmaude.co.uk/posts/managing-a-bitbucket-users-permissions-when-theyve-left-your-team" rel="alternate"></link><published>2016-04-16T01:54:00+01:00</published><updated>2016-04-16T01:54:00+01:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-04-16:posts/managing-a-bitbucket-users-permissions-when-theyve-left-your-team</id><summary type="html">&lt;h2&gt;Kicking the Bitbucket&lt;/h2&gt;
 &lt;p&gt;What I noticed this week is that users who'd left a Bitbucket team&lt;sup id="fnref:1"&gt;&lt;a class="footnote-ref" href="#fn:1" rel="footnote"&gt;1&lt;/a&gt;&lt;/sup&gt;
 that I'm currently a member of were still billed as having admin access
 to several repositories. But, this wasn't by virtue of being a team

--- a/index.html
+++ b/index.html
@@ -350,18 +350,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index2.html
+++ b/index2.html
@@ -391,18 +391,18 @@ generators.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index3.html
+++ b/index3.html
@@ -432,18 +432,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index4.html
+++ b/index4.html
@@ -460,18 +460,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index5.html
+++ b/index5.html
@@ -476,18 +476,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index6.html
+++ b/index6.html
@@ -480,18 +480,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index7.html
+++ b/index7.html
@@ -476,18 +476,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index8.html
+++ b/index8.html
@@ -363,18 +363,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/p/contact.html
+++ b/p/contact.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html><html><head><link rel="canonical" href="/pages/contact-me"/>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<!DOCTYPE html><html><head><meta charset="utf-8" />
 <meta http-equiv="refresh" content="0;url=/pages/contact-me" />
 </head></html>

--- a/pages/contact-me.html
+++ b/pages/contact-me.html
@@ -136,18 +136,18 @@ here)stevenmaude.co.uk</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/52-weeks-52-posts.html
+++ b/posts/52-weeks-52-posts.html
@@ -182,18 +182,18 @@ I'm going to do things.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/a-beginners-guide-to-os-encryption-dual.html
+++ b/posts/a-beginners-guide-to-os-encryption-dual.html
@@ -333,18 +333,18 @@ concern</a>.&#160;<a class="footnote-backref" href="#fnref:1" rev="footnote" tit
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/android-device-encryption-is-mostly-good.html
+++ b/posts/android-device-encryption-is-mostly-good.html
@@ -192,18 +192,18 @@ definitely welcome.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/answers-to-some-windows-10-activation-questions.html
+++ b/posts/answers-to-some-windows-10-activation-questions.html
@@ -228,18 +228,18 @@ Windows 10 seemed stable enough.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/archiving-a-wordpress-site-with-wget-and-hosting-for-free.html
+++ b/posts/archiving-a-wordpress-site-with-wget-and-hosting-for-free.html
@@ -139,7 +139,7 @@ site archiving, hit a problem and then discover which <code>wget</code> option y
 have used to fix it. The upside is that <code>wget</code> probably does feature the option
 you require.</p>
 <p>After lots of trial and error, what I ended up with was (deep breath):</p>
-<div class="highlight"><pre>wget --page-requisites --convert-links --adjust-extension --mirror --span-hosts --domains<span class="o">=</span>blog.scraperwiki.com,scraperwiki.com --exclude-domains beta.scraperwiki.com,classic.scraperwiki.com,media.scraperwiki.com,mot.scraperwiki.com,newsreader.scraperwiki.com,premium.scraperwiki.com,status.scraperwiki.com,x.scraperwiki.com scraperwiki.com
+<div class="highlight"><pre><span></span>wget --page-requisites --convert-links --adjust-extension --mirror --span-hosts --domains<span class="o">=</span>blog.scraperwiki.com,scraperwiki.com --exclude-domains beta.scraperwiki.com,classic.scraperwiki.com,media.scraperwiki.com,mot.scraperwiki.com,newsreader.scraperwiki.com,premium.scraperwiki.com,status.scraperwiki.com,x.scraperwiki.com scraperwiki.com
 </pre></div>
 
 
@@ -238,7 +238,7 @@ gets correctly requested as a filename with a question mark in it. Not
 particularly clean, but it worked. It may have just been using a recent
 version of <code>wget</code> that solved this. This was nice as the alternative was
 a horrendous find/replace task using commands like:</p>
-<div class="highlight"><pre>find . -type f -exec grep -Iq . <span class="o">{}</span> <span class="se">\;</span> -and -exec sed -i
+<div class="highlight"><pre><span></span>find . -type f -exec grep -Iq . <span class="o">{}</span> <span class="se">\;</span> -and -exec sed -i
 <span class="s1">&#39;s!wp-content/plugins/jetpack/css/jetpack.css?ver=4.1.1!wp-content/plugins/jetpack/css/jetpack.css!g&#39;</span>
 <span class="o">{}</span> <span class="se">\;</span>
 </pre></div>
@@ -363,18 +363,18 @@ tips here might help you with your migration.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/arduous-lessons-in-python-why-main-is.html
+++ b/posts/arduous-lessons-in-python-why-main-is.html
@@ -136,7 +136,7 @@ That is, I wasn't seeing any pass/fail indicators, which was strange.</p>
 <p>Something was running that evidently wasn't what I intended.</p>
 <p>On inspection, one of the import statements in the test code had a
 structure somewhat like:</p>
-<div class="highlight"><pre><span class="k">def</span> <span class="nf">some_function</span><span class="p">():</span>
+<div class="highlight"><pre><span></span><span class="k">def</span> <span class="nf">some_function</span><span class="p">():</span>
     <span class="n">do</span> <span class="n">some</span> <span class="n">things</span>
 
 <span class="k">def</span> <span class="nf">another_function</span><span class="p">():</span>
@@ -161,7 +161,7 @@ eventually, the tests would have run, but they'd run <em>after</em> the code in
 the <code>import</code> had finished, which would have taken <strong>hours</strong>.</p>
 <h2>Fixing the problem</h2>
 <p>Normally, I routinely use:</p>
-<div class="highlight"><pre><span class="k">if</span> <span class="n">__name__</span> <span class="o">==</span> <span class="s">&#39;__main__&#39;</span><span class="p">:</span>
+<div class="highlight"><pre><span></span><span class="k">if</span> <span class="n">__name__</span> <span class="o">==</span> <span class="s1">&#39;__main__&#39;</span><span class="p">:</span>
     <span class="n">main</span><span class="p">()</span>
 </pre></div>
 
@@ -230,18 +230,18 @@ tests were the only other module that we'd imported the code into.)</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/as-easy-as-123-reg.html
+++ b/posts/as-easy-as-123-reg.html
@@ -332,18 +332,18 @@ domain is for use by a "UK Individual".</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/beatmatching-five-reasons-why-digital.html
+++ b/posts/beatmatching-five-reasons-why-digital.html
@@ -341,18 +341,18 @@ have been correctly beatgridded.&#160;<a class="footnote-backref" href="#fnref:3
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/beatmatching-to-beat-grid-in-traktor.html
+++ b/posts/beatmatching-to-beat-grid-in-traktor.html
@@ -195,18 +195,18 @@ Ableton.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/beware-pythons-pyc-files.html
+++ b/posts/beware-pythons-pyc-files.html
@@ -164,18 +164,18 @@ your coding workflow.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/blogger-versus-wordpress-revisited.html
+++ b/posts/blogger-versus-wordpress-revisited.html
@@ -266,18 +266,18 @@ I'll describe the advantages of those in a later post.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/blogger-versus-wordpress.html
+++ b/posts/blogger-versus-wordpress.html
@@ -174,18 +174,18 @@ than just using a stock template.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/book-and-talk-review-making-music-74-creative-strategies-for-electronic-music-producers.html
+++ b/posts/book-and-talk-review-making-music-74-creative-strategies-for-electronic-music-producers.html
@@ -317,18 +317,18 @@ learners.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/book-review-data-science-for-business.html
+++ b/posts/book-review-data-science-for-business.html
@@ -214,18 +214,18 @@ if you want to check it out before buying.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/chatting-about-data-science-careers.html
+++ b/posts/chatting-about-data-science-careers.html
@@ -255,18 +255,18 @@ interviews.&#160;<a class="footnote-backref" href="#fnref:3" rev="footnote" titl
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/close-to-edit-what-researchers-can.html
+++ b/posts/close-to-edit-what-researchers-can.html
@@ -231,18 +231,18 @@ page.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/collecting-disposable-email-with-go-mailin8.html
+++ b/posts/collecting-disposable-email-with-go-mailin8.html
@@ -136,7 +136,7 @@ address, loading the inbox page, and clicking the mail to display it and
 then finally copying the activation or download URL I'm looking for.</p>
 <p>Much easier if I can just run a command line program that just takes the
 local-part of the mailbox name (the part before the @):</p>
-<div class="highlight"><pre>./go-mailin8 &lt;<span class="nb">local</span>-part&gt;
+<div class="highlight"><pre><span></span>./go-mailin8 &lt;local-part&gt;
 </pre></div>
 
 
@@ -192,18 +192,18 @@ computer nonetheless.)</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/converting-pdfs-to-series-of-images.html
+++ b/posts/converting-pdfs-to-series-of-images.html
@@ -127,7 +127,7 @@ cropping the copied image. But, since I already had
 <a href="http://www.imagemagick.org/">ImageMagick</a> installed, I thought I should
 try automatically converting the PDF slides to individual images.</p>
 <p>A command like:</p>
-<div class="highlight"><pre>convert -density <span class="m">300</span> input.pdf outputname_%0d.png
+<div class="highlight"><pre><span></span>convert -density <span class="m">300</span> input.pdf outputname_%0d.png
 </pre></div>
 
 
@@ -175,18 +175,18 @@ PDF</a> which is named
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/courseras-introduction-to-data-science.html
+++ b/posts/courseras-introduction-to-data-science.html
@@ -260,18 +260,18 @@ wouldn't hesitate to recommend it. Thanks to the staff for providing it!</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/dariks-boot-and-nuke-unrecognized.html
+++ b/posts/dariks-boot-and-nuke-unrecognized.html
@@ -203,18 +203,18 @@ in wiping the HDD, this isn't an issue.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/differences-between-working-in.html
+++ b/posts/differences-between-working-in.html
@@ -309,18 +309,18 @@ time was largely an easygoing one.&#160;<a class="footnote-backref" href="#fnref
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/ensuring-scheduled-cron-jobs-are-run.html
+++ b/posts/ensuring-scheduled-cron-jobs-are-run.html
@@ -136,7 +136,7 @@ that although
 <code>man</code>
 was still running perfectly fine, I was getting this
 message:</p>
-<div class="highlight"><pre>man: can&#39;t resolve /usr/share/man/man6/LS.6.gz: No such file or
+<div class="highlight"><pre><span></span>man: can&#39;t resolve /usr/share/man/man6/LS.6.gz: No such file or
 directory
 </pre></div>
 
@@ -147,7 +147,7 @@ one</a>; just run
 database caches. Looking more closely, I found that a <code>mandb</code>
 job was actually in cron.daily which means that it should run daily.
 However, when I checked the syslog with:</p>
-<div class="highlight"><pre>grep cron.daily /var/log/syslog
+<div class="highlight"><pre><span></span>grep cron.daily /var/log/syslog
 </pre></div>
 
 
@@ -161,7 +161,7 @@ once I've finished with it.</p>
 install anacron</code>, you should find an
 <code>/etc/anacrontab</code>
 containing lines like:</p>
-<div class="highlight"><pre><span class="m">1</span> <span class="m">5</span> cron.daily run-parts --report /etc/cron.daily
+<div class="highlight"><pre><span></span><span class="m">1</span> <span class="m">5</span> cron.daily run-parts --report /etc/cron.daily
 <span class="m">7</span> <span class="m">10</span> cron.weekly run-parts --report /etc/cron.weekly
 @monthly <span class="m">15</span> cron.monthly run-parts --report /etc/cron.monthly
 </pre></div>
@@ -174,12 +174,12 @@ There's then a user-specified delay before anacron runs each task; here,
 it's 5 minutes for <code>/etc/cron.daily</code>, 10 minutes for <code>/etc/cron.weekly</code>
 and 15 minutes for <code>/etc/cron.monthly</code>.
 If you then restart and wait five minutes or so, then do:</p>
-<div class="highlight"><pre>grep cron.daily /var/log/syslog
+<div class="highlight"><pre><span></span>grep cron.daily /var/log/syslog
 </pre></div>
 
 
 <p>should show lines like:</p>
-<div class="highlight"><pre>Jan 31 10:28:02 raspberrypi anacron[2105]: Will run job `cron.daily&#39; in
+<div class="highlight"><pre><span></span>Jan 31 10:28:02 raspberrypi anacron[2105]: Will run job `cron.daily&#39; in
 5 min.
 Jan 31 10:33:21 raspberrypi anacron[2105]: Job `cron.daily&#39; started
 Jan 31 10:33:21 raspberrypi anacron[2692]: Updated timestamp for
@@ -231,18 +231,18 @@ gave a very clear and helpful explanation of how the two interoperate.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/explaining-python-virtualenv-in-under.html
+++ b/posts/explaining-python-virtualenv-in-under.html
@@ -239,18 +239,18 @@ is a handy way to manage virtualenvs.)</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/explaining-python-virtualenvwrapper-in.html
+++ b/posts/explaining-python-virtualenvwrapper-in.html
@@ -136,8 +136,8 @@ non-standard location:<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel
 <a href="http://askubuntu.com/questions/251378/where-is-virtualenvwrapper-sh">but the unexpected <code>/etc/bash_completion_d/virtualenvwrapper</code></a>.</p>
 <p>Once installed, add the following two lines to
 your shell startup file e.g. <code>.bashrc</code></p>
-<div class="highlight"><pre><span class="nb">source</span> /etc/bash_completion_d/virtualenvwrapper
-<span class="nb">export </span><span class="nv">WORKON_HOME</span><span class="o">=</span>~/path/to/your/virtualenvs
+<div class="highlight"><pre><span></span><span class="nb">source</span> /etc/bash_completion_d/virtualenvwrapper
+<span class="nb">export</span> <span class="nv">WORKON_HOME</span><span class="o">=</span>~/path/to/your/virtualenvs
 </pre></div>
 
 
@@ -166,7 +166,7 @@ want to switch to the virtualenv without working on that project.</p>
 <code>cd $VIRTUALENVWRAPPER_HOOK_DIR</code></p>
 <p>You'll find the <code>postactivate</code>
 file in there. Add the following two lines to it:</p>
-<div class="highlight"><pre><span class="nv">proj_name</span><span class="o">=</span><span class="k">$(</span><span class="nb">echo</span> <span class="nv">$VIRTUAL_ENV</span><span class="p">|</span>awk -F<span class="s1">&#39;/&#39;</span> <span class="s1">&#39;{print $NF}&#39;</span><span class="k">)</span>
+<div class="highlight"><pre><span></span><span class="nv">proj_name</span><span class="o">=</span><span class="k">$(</span><span class="nb">echo</span> <span class="nv">$VIRTUAL_ENV</span><span class="p">|</span>awk -F<span class="s1">&#39;/&#39;</span> <span class="s1">&#39;{print $NF}&#39;</span><span class="k">)</span>
 <span class="nb">cd</span> ~/project_dir_name/<span class="nv">$proj_name</span>
 </pre></div>
 
@@ -248,18 +248,18 @@ standard location and should circumvent this problem entirely.)&#160;<a class="f
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/firefox-21-annoyances.html
+++ b/posts/firefox-21-annoyances.html
@@ -193,18 +193,18 @@ clicked, and then ignore it for no discernable reason.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/firefox-keyword-searches-and-how-to-fix-adding-them.html
+++ b/posts/firefox-keyword-searches-and-how-to-fix-adding-them.html
@@ -219,18 +219,18 @@ Firefox profiles.&#160;<a class="footnote-backref" href="#fnref:1" rev="footnote
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/fixing-chromium-on-ubuntu-video.html
+++ b/posts/fixing-chromium-on-ubuntu-video.html
@@ -127,7 +127,7 @@ could avoid it. (HTML5 in Firefox was working fine.) All I got in
 Chromium was a black screen with a spinner going endlessly,.</p>
 <p>In the end, <a href="http://askubuntu.com/questions/331769/youtube-is-not-working">the solution was as simple as missing
 codecs</a>:</p>
-<div class="highlight"><pre>sudo apt-get install chromium-codecs-ffmpeg-extra
+<div class="highlight"><pre><span></span>sudo apt-get install chromium-codecs-ffmpeg-extra
 </pre></div>
 
 
@@ -172,18 +172,18 @@ remember.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/fixing-no-ink-levels-being-displayed-in.html
+++ b/posts/fixing-no-ink-levels-being-displayed-in.html
@@ -180,18 +180,18 @@ Utility</strong>.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/full-circle.html
+++ b/posts/full-circle.html
@@ -238,18 +238,18 @@ can deploy the site to GitHub Pages, then focus on writing again.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/getting-an-official-windows-10-disk-image.html
+++ b/posts/getting-an-official-windows-10-disk-image.html
@@ -129,7 +129,7 @@ Pro.  The actual ISO disk image is buried on the site under <a href="https://www
 Bench"</a>.</p>
 <p>Though the filename differed, the 64-bit download from that page <em>did</em> match
 the SHA1 as listed on the MSDN site as of 2015-10-23:</p>
-<div class="highlight"><pre>File Name: en_windows_10_multiple_editions_x64_dvd_6846432.iso
+<div class="highlight"><pre><span></span>File Name: en_windows_10_multiple_editions_x64_dvd_6846432.iso
 Languages: English
 SHA1: 60CCE9E9C6557335B4F7B18D02CFE2B438A8B3E2
 </pre></div>
@@ -190,18 +190,18 @@ installer prompts you to choose the version to install.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/heartbleed-ill-communication.html
+++ b/posts/heartbleed-ill-communication.html
@@ -182,18 +182,18 @@ better job in clarifying their position.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/hiding-draft-articles-in-pelican.html
+++ b/posts/hiding-draft-articles-in-pelican.html
@@ -210,18 +210,18 @@ Haven't tried this.)</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/horrible-wireless-network-pings-in.html
+++ b/posts/horrible-wireless-network-pings-in.html
@@ -129,7 +129,7 @@ stevenmaude.co.uk            </a>
 Ubuntu as I need to demo some of my work. About two minutes before it
 was due to begin, I noticed that my pings to the home network router
 were ridiculously variable and high:</p>
-<div class="highlight"><pre>PING 192.168.0.1 (192.168.0.1) 56(84) bytes of data.
+<div class="highlight"><pre><span></span>PING 192.168.0.1 (192.168.0.1) 56(84) bytes of data.
 64 bytes from 192.168.0.1: icmp_req=1 ttl=64 time=60.3 ms
 64 bytes from 192.168.0.1: icmp_req=2 ttl=64 time=82.9 ms
 64 bytes from 192.168.0.1: icmp_req=3 ttl=64 time=105 ms
@@ -144,12 +144,12 @@ Fortunately, it didn't seem to adversely affect the call.</p>
 ms)<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel="footnote">1</a></sup>. So, what's the issue under Linux?</p>
 <p>What it turns out to be is wireless power management. You can easily
 test this by trying:</p>
-<div class="highlight"><pre>sudo iwconfig wlan0 power off
+<div class="highlight"><pre><span></span>sudo iwconfig wlan0 power off
 </pre></div>
 
 
 <p>and remeasuring the pings:</p>
-<div class="highlight"><pre>64 bytes from 192.168.0.1: icmp_req=1 ttl=64 time=0.970 ms
+<div class="highlight"><pre><span></span>64 bytes from 192.168.0.1: icmp_req=1 ttl=64 time=0.970 ms
 64 bytes from 192.168.0.1: icmp_req=2 ttl=64 time=1.04 ms
 64 bytes from 192.168.0.1: icmp_req=3 ttl=64 time=0.994 ms
 </pre></div>
@@ -159,19 +159,19 @@ test this by trying:</p>
 <p><a href="http://ubuntuforums.org/showthread.php?t=1686641">Thanks to this forum
 thread</a>, I found an
 easy way to make this fix permanent, you need to do something like:</p>
-<div class="highlight"><pre>sudo nano /etc/pm/power.d/wireless
+<div class="highlight"><pre><span></span>sudo nano /etc/pm/power.d/wireless
 </pre></div>
 
 
 <p>and add the following lines to the newly created file:</p>
-<div class="highlight"><pre><span class="c">#!/bin/sh</span>
+<div class="highlight"><pre><span></span><span class="ch">#!/bin/sh</span>
 
 /sbin/iwconfig wlan0 power off
 </pre></div>
 
 
 <p>Next, do:</p>
-<div class="highlight"><pre>sudo chmod +x /etc/pm/power.d/wireless
+<div class="highlight"><pre><span></span>sudo chmod +x /etc/pm/power.d/wireless
 </pre></div>
 
 
@@ -224,18 +224,18 @@ you'd suffer a similar problem in Windows too otherwise.&#160;<a class="footnote
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-access-github-over-ssh-on-ubuntu.html
+++ b/posts/how-to-access-github-over-ssh-on-ubuntu.html
@@ -233,18 +233,18 @@ machines too.&#160;<a class="footnote-backref" href="#fnref:2" rev="footnote" ti
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-delete-directories-that-respawn.html
+++ b/posts/how-to-delete-directories-that-respawn.html
@@ -168,18 +168,18 @@ command</strong> to prevent the pesky thing returning again once and for all.</p
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-give-back-to-open-source-software.html
+++ b/posts/how-to-give-back-to-open-source-software.html
@@ -267,18 +267,18 @@ help with.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-secure-your-storage-and-backup.html
+++ b/posts/how-to-secure-your-storage-and-backup.html
@@ -310,18 +310,18 @@ you're using.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-use-mock-in-python-to-mock.html
+++ b/posts/how-to-use-mock-in-python-to-mock.html
@@ -167,16 +167,16 @@ to do something similar. In this case, I wanted to test a method of an
 object, but wasn't sure how to do that using a mock.</p>
 <p>This is a really cut-down version of what my code was doing, but
 features the main thing I was testing:</p>
-<div class="highlight"><pre><span class="kn">import</span> <span class="nn">sqlite3</span>
+<div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">sqlite3</span>
 
 
 <span class="k">def</span> <span class="nf">main</span><span class="p">():</span>
-    <span class="n">table_name</span> <span class="o">=</span> <span class="s">&#39;some_table&#39;</span>
-    <span class="n">sqlite_db</span> <span class="o">=</span> <span class="n">sqlite3</span><span class="o">.</span><span class="n">connect</span><span class="p">(</span><span class="s">&#39;database.sqlite&#39;</span><span class="p">)</span>
-    <span class="n">sqlite_db</span><span class="o">.</span><span class="n">execute</span><span class="p">(</span><span class="s">&quot;drop table if exists {};&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">table_name</span><span class="p">))</span>
-    <span class="c"># next, get some data and then save to db</span>
+    <span class="n">table_name</span> <span class="o">=</span> <span class="s1">&#39;some_table&#39;</span>
+    <span class="n">sqlite_db</span> <span class="o">=</span> <span class="n">sqlite3</span><span class="o">.</span><span class="n">connect</span><span class="p">(</span><span class="s1">&#39;database.sqlite&#39;</span><span class="p">)</span>
+    <span class="n">sqlite_db</span><span class="o">.</span><span class="n">execute</span><span class="p">(</span><span class="s2">&quot;drop table if exists {};&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">table_name</span><span class="p">))</span>
+    <span class="c1"># next, get some data and then save to db</span>
 
-<span class="k">if</span> <span class="n">__name__</span> <span class="o">==</span> <span class="s">&#39;__main__&#39;</span><span class="p">:</span>
+<span class="k">if</span> <span class="n">__name__</span> <span class="o">==</span> <span class="s1">&#39;__main__&#39;</span><span class="p">:</span>
     <span class="n">main</span><span class="p">()</span>
 </pre></div>
 
@@ -201,17 +201,17 @@ of accessing the call via the <code>mock_sqlite3_connect</code>. What it took me
 ages to realise is that I had to mock out what <code>sqlite3.connect()</code>
 returns; you can't (unless I'm mistaken) access calls on the object it
 returns otherwise.</p>
-<div class="highlight"><pre><span class="kn">import</span> <span class="nn">unittest</span>
+<div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">unittest</span>
 <span class="kn">import</span> <span class="nn">code_to_test</span>
 <span class="kn">import</span> <span class="nn">mock</span>
 
 <span class="k">class</span> <span class="nc">CodeToTestTestCase</span><span class="p">(</span><span class="n">unittest</span><span class="o">.</span><span class="n">TestCase</span><span class="p">):</span>
-    <span class="nd">@mock.patch</span><span class="p">(</span><span class="s">&#39;code_to_test.sqlite3.connect&#39;</span><span class="p">)</span>
+    <span class="nd">@mock.patch</span><span class="p">(</span><span class="s1">&#39;code_to_test.sqlite3.connect&#39;</span><span class="p">)</span>
     <span class="k">def</span> <span class="nf">test_database_drop_table_call</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">mock_sqlite3_connect</span><span class="p">):</span>
         <span class="n">sqlite_execute_mock</span> <span class="o">=</span> <span class="n">mock</span><span class="o">.</span><span class="n">Mock</span><span class="p">()</span>
         <span class="n">mock_sqlite3_connect</span><span class="o">.</span><span class="n">return_value</span> <span class="o">=</span> <span class="n">sqlite_execute_mock</span>
         <span class="n">code_to_test</span><span class="o">.</span><span class="n">main</span><span class="p">()</span>
-        <span class="n">call</span> <span class="o">=</span> <span class="s">&#39;drop table if exists some_table;&#39;</span>
+        <span class="n">call</span> <span class="o">=</span> <span class="s1">&#39;drop table if exists some_table;&#39;</span>
         <span class="n">sqlite_execute_mock</span><span class="o">.</span><span class="n">execute</span><span class="o">.</span><span class="n">assert_called_with</span><span class="p">(</span><span class="n">call</span><span class="p">)</span>
 </pre></div>
 
@@ -273,18 +273,18 @@ I'll be much quicker to get something going.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-universities-can-help-develop.html
+++ b/posts/how-universities-can-help-develop.html
@@ -310,18 +310,18 @@ you've worked in for so long.&#160;<a class="footnote-backref" href="#fnref:1" r
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/installing-bokeh-on-ubuntu-1204-lts.html
+++ b/posts/installing-bokeh-on-ubuntu-1204-lts.html
@@ -123,12 +123,12 @@ look at, so I figured it was a good excuse to give
 <p>I was <a href="http://bokeh.pydata.org/quickstart.html">installing from source</a>
 and found that on doing
 <code>pip install -r requirements.txt</code> that the install of gevent was failing:</p>
-<div class="highlight"><pre>gevent:
+<div class="highlight"><pre><span></span>gevent:
 gevent/libevent.h:9:19: fatal error: event.h: No such file or directory
 
 compilation terminated.
 
-error: <span class="nb">command</span> <span class="s1">&#39;gcc&#39;</span> failed with <span class="nb">exit </span>status 1
+error: <span class="nb">command</span> <span class="s1">&#39;gcc&#39;</span> failed with <span class="nb">exit</span> status 1
 </pre></div>
 
 
@@ -187,18 +187,18 @@ in a few months.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/installing-matplotlib-in-virtualenv.html
+++ b/posts/installing-matplotlib-in-virtualenv.html
@@ -162,7 +162,7 @@ matplotlib already. You also need to
 virtualenv</a>
 which helped fix this. Activate the virtualenv you want to use
 matplotlib in, then do:</p>
-<div class="highlight"><pre>ln -sf /usr/lib/python2.7/dist-packages/<span class="o">{</span>glib,gobject,cairo,gtk-2.0,pygtk.py,pygtk.pth<span class="o">}</span> <span class="nv">$VIRTUAL_ENV</span>/lib/python2.7/site-packages
+<div class="highlight"><pre><span></span>ln -sf /usr/lib/python2.7/dist-packages/<span class="o">{</span>glib,gobject,cairo,gtk-2.0,pygtk.py,pygtk.pth<span class="o">}</span> <span class="nv">$VIRTUAL_ENV</span>/lib/python2.7/site-packages
 </pre></div>
 
 
@@ -221,18 +221,18 @@ the minimum of required packages.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/installing-python-modules-on-windows.html
+++ b/posts/installing-python-modules-on-windows.html
@@ -180,18 +180,18 @@ compiled Python scientific packages available.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/its-not-often-that-i-think-of-technical.html
+++ b/posts/its-not-often-that-i-think-of-technical.html
@@ -201,18 +201,18 @@ enough? Who knows.&#160;<a class="footnote-backref" href="#fnref:1" rev="footnot
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/job-advertisements.html
+++ b/posts/job-advertisements.html
@@ -168,18 +168,18 @@ be able to ensure that everyone gets an equal share?"</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/leaky-phone-apps.html
+++ b/posts/leaky-phone-apps.html
@@ -192,18 +192,18 @@ to help deal with this issue.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/making-aero-theme-settings-stick-in.html
+++ b/posts/making-aero-theme-settings-stick-in.html
@@ -181,18 +181,18 @@ will actually be retained when you next log on.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/making-midi-keyboard-modulation-wheel.html
+++ b/posts/making-midi-keyboard-modulation-wheel.html
@@ -183,18 +183,18 @@ directories and save the .flp file in there.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/managing-a-bitbucket-users-permissions-when-theyve-left-your-team.html
+++ b/posts/managing-a-bitbucket-users-permissions-when-theyve-left-your-team.html
@@ -204,18 +204,18 @@ might allow you to switch to a cheaper Bitbucket plan for your team too.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/migrating-email-from-pop-to-imap.html
+++ b/posts/migrating-email-from-pop-to-imap.html
@@ -224,18 +224,18 @@ Repeat for each mail folder.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/my-wifis-connected-but-theres-no.html
+++ b/posts/my-wifis-connected-but-theres-no.html
@@ -154,7 +154,7 @@ modprobe option that disables the wireless N feature of the Intel
 wireless adapter. (<code>lshw -C network</code> states the model is "Centrino
 Wireless-N 2230".)</p>
 <p>By running the commands</p>
-<div class="highlight"><pre>sudo rmmod iwldvm
+<div class="highlight"><pre><span></span>sudo rmmod iwldvm
 sudo rmmod iwlwifi
 sudo modprobe iwlwifi <span class="nv">11n_disable</span><span class="o">=</span>1
 sudo modprobe iwldvm
@@ -175,7 +175,7 @@ sensible to use it when there was an alternative.)</p>
 new <code>.conf</code> file:</p>
 <p><code>/etc/modprobe.d/wireless-n-fix-iwlwifi.conf</code>, adding just this line to
 the file:</p>
-<div class="highlight"><pre>options iwlwifi <span class="nv">11n_disable</span><span class="o">=</span>1
+<div class="highlight"><pre><span></span>options iwlwifi <span class="nv">11n_disable</span><span class="o">=</span>1
 </pre></div>
 
 
@@ -230,18 +230,18 @@ yet it's still present... but at least there's a workaround.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/odd-behaviour-of-bitlocker-or-maybe-my.html
+++ b/posts/odd-behaviour-of-bitlocker-or-maybe-my.html
@@ -185,18 +185,18 @@ similar.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/patching-android-roms-for-pdroid-using.html
+++ b/posts/patching-android-roms-for-pdroid-using.html
@@ -208,18 +208,18 @@ finished!</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/phone-upgrades-and-privacy-downgrades.html
+++ b/posts/phone-upgrades-and-privacy-downgrades.html
@@ -209,18 +209,18 @@ moment, so I think I'll try and see how I get on with stock for now.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/pypi-releasing-frustration.html
+++ b/posts/pypi-releasing-frustration.html
@@ -162,7 +162,7 @@ message telling you that the version already exists and only then increase the
 version number.</p>
 <p>The details in the guide show the structure of the <code>.pypirc</code> configuration.
 However, they don't point out that you can also add the PyPI test site too:</p>
-<div class="highlight"><pre>[distutils]
+<div class="highlight"><pre><span></span>[distutils]
 index-servers=
     pypi
     testpypi
@@ -189,12 +189,12 @@ be released.  </p>
 which arguments you should use with <code>setup.py</code> to build your package.</p>
 <p>If you're trying to build Python wheels, one hiccup is that you likely need the
 <code>wheel</code> package installed. Otherwise, you may find with a command like:</p>
-<div class="highlight"><pre>python setup.py sdist bdist_wheel
+<div class="highlight"><pre><span></span>python setup.py sdist bdist_wheel
 </pre></div>
 
 
 <p>you get the error:</p>
-<div class="highlight"><pre>error: invalid command &#39;bdist_wheel&#39;
+<div class="highlight"><pre><span></span>error: invalid command &#39;bdist_wheel&#39;
 </pre></div>
 
 
@@ -207,7 +207,7 @@ Python 2.7.</p>
 register the project. Note that you need to specify the repository using <code>-r</code>
 if you want to use something other than the default, and the name is taken from
 your <code>.pypirc</code>.</p>
-<div class="highlight"><pre>Registering bbc-radio-tracklisting-downloader-0.0.1.tar.gz
+<div class="highlight"><pre><span></span>Registering bbc-radio-tracklisting-downloader-0.0.1.tar.gz
 UnicodeDecodeError: &#39;ascii&#39; codec can&#39;t decode byte 0xc2 in position 27:
 ordinal not in range(128)
 </pre></div>
@@ -218,7 +218,7 @@ nothing to indicate where the problem lay at all, making it very difficult to
 start fixing it.</p>
 <p>Switching to Python 3.4 for the upload avoided the Unicode error, but instead
 gave me:</p>
-<div class="highlight"><pre>HTTPError: 401 Client Error: You must login to access this feature for
+<div class="highlight"><pre><span></span>HTTPError: 401 Client Error: You must login to access this feature for
 url: https://pypi.python.org/pypi
 </pre></div>
 
@@ -252,7 +252,7 @@ whether read in from a file, or included in full in the <code>setup.py</code> it
 </ul>
 <p>I went for the latter for simplicity.</p>
 <p>Using <code>pandoc</code>, it's pretty simple to convert an existing Markdown file:</p>
-<div class="highlight"><pre>pandoc --from<span class="o">=</span>markdown --to<span class="o">=</span>rst --output<span class="o">=</span>README.rst README.md
+<div class="highlight"><pre><span></span>pandoc --from<span class="o">=</span>markdown --to<span class="o">=</span>rst --output<span class="o">=</span>README.rst README.md
 </pre></div>
 
 
@@ -263,7 +263,7 @@ generated. </p>
 <h3>Uploading</h3>
 <p>Whew! Back to <code>twine</code>, and now the project's registered, let's try uploading it
 via:</p>
-<div class="highlight"><pre>twine upload dist/* -r testpypi
+<div class="highlight"><pre><span></span>twine upload dist/* -r testpypi
 </pre></div>
 
 
@@ -341,18 +341,18 @@ not worth the trouble to release on PyPI.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/restoring-a-tag-cloud-dispersed-by-pelican-360.html
+++ b/posts/restoring-a-tag-cloud-dispersed-by-pelican-360.html
@@ -199,18 +199,18 @@ that shows up in the upper right sidebar.&#160;<a class="footnote-backref" href=
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/rockbox-ipod-nano-2g-and-inverted-audio.html
+++ b/posts/rockbox-ipod-nano-2g-and-inverted-audio.html
@@ -175,18 +175,18 @@ easy fix, of course, is to just switch headphones around.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/scraping-natures-job-website.html
+++ b/posts/scraping-natures-job-website.html
@@ -176,18 +176,18 @@ Full instructions are on
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/securely-erasing-frozen-hard-disks-with-hdparm.html
+++ b/posts/securely-erasing-frozen-hard-disks-with-hdparm.html
@@ -132,7 +132,7 @@ accidentally type the wrong thing that you won't erase a drive that you
 didn't intend to.</p>
 <p>Next, you need to get the drive's name. Open a terminal by pressing
 Ctrl+Alt+T.</p>
-<div class="highlight"><pre>sudo lshw -class disk
+<div class="highlight"><pre><span></span>sudo lshw -class disk
 </pre></div>
 
 
@@ -146,10 +146,10 @@ advises it due to problems with certain PCs, and it only takes one extra
 command. Note that the "foo" password below can be replaced by something
 of your choice, but it doesn't really matter; when the drive is erased,
 the password should be removed.</p>
-<div class="highlight"><pre><span class="nv">$ </span>sudo hdparm --user-master u --security-set-pass foo /dev/sdX
+<div class="highlight"><pre><span></span>$ sudo hdparm --user-master u --security-set-pass foo /dev/sdX
 security_password: <span class="s2">&quot;foo&quot;</span>
 /dev/sdX:
- Issuing SECURITY_SET_PASS <span class="nb">command</span>, <span class="nv">password</span><span class="o">=</span><span class="s2">&quot;foo&quot;</span>, <span class="nv">user</span><span class="o">=</span>user, <span class="nv">mode</span><span class="o">=</span>high
+ Issuing SECURITY_SET_PASS command, <span class="nv">password</span><span class="o">=</span><span class="s2">&quot;foo&quot;</span>, <span class="nv">user</span><span class="o">=</span>user, <span class="nv">mode</span><span class="o">=</span>high
 SECURITY_SET_PASS: Input/output error
 </pre></div>
 
@@ -159,7 +159,7 @@ SECURITY_SET_PASS: Input/output error
 You might expect it if the drive has a password set already, but in this
 case I couldn't recall doing that. If that's the same for you, it could
 be a simple fix.  First, check the drive's current status via:</p>
-<div class="highlight"><pre><span class="nv">$ </span>sudo hdparm -I /dev/sdX
+<div class="highlight"><pre><span></span>$ sudo hdparm -I /dev/sdX
 </pre></div>
 
 
@@ -180,7 +180,7 @@ opposed to "not enabled".</p>
 <p>You can now proceed with the erase. If your drive's <code>hdparm</code> output
 states <code>supported: enhanced erase</code>, you could replace the
 <code>--security-erase</code> below with <code>--security-erase-enhanced</code>:</p>
-<div class="highlight"><pre><span class="nv">$ </span>sudo <span class="nb">time </span>hdparm --user-master u --security-erase foo /dev/sdX
+<div class="highlight"><pre><span></span>$ sudo <span class="nb">time</span> hdparm --user-master u --security-erase foo /dev/sdX
 </pre></div>
 
 
@@ -224,18 +224,18 @@ enabled".</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/securely-erasing-ssd-drives.html
+++ b/posts/securely-erasing-ssd-drives.html
@@ -193,18 +193,18 @@ using shred or dd.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/some-spring-winter-ubuntu-cleaning.html
+++ b/posts/some-spring-winter-ubuntu-cleaning.html
@@ -148,13 +148,13 @@ versions.</p>
 <p><a href="http://askubuntu.com/a/153193">This is a fairly simple way from the command line; I'll summarise it
 here.</a></p>
 <p>Check which kernel is currently in use:</p>
-<div class="highlight"><pre>uname -r
+<div class="highlight"><pre><span></span>uname -r
 </pre></div>
 
 
 <p><strong>Do not remove the kernel image that uname returns!</strong></p>
 <p>List the other kernels that are installed:</p>
-<div class="highlight"><pre>dpkg --list <span class="p">|</span> grep linux-image
+<div class="highlight"><pre><span></span>dpkg --list <span class="p">|</span> grep linux-image
 </pre></div>
 
 
@@ -162,7 +162,7 @@ here.</a></p>
 others that aren't. These are safe to remove.</p>
 <p>To remove a kernel image, <strong>not the one listed from the
 <code>uname</code> command:</strong></p>
-<div class="highlight"><pre>sudo apt-get purge linux-image-x.x.x.x-generic
+<div class="highlight"><pre><span></span>sudo apt-get purge linux-image-x.x.x.x-generic
 </pre></div>
 
 
@@ -170,7 +170,7 @@ others that aren't. These are safe to remove.</p>
 in case you need to revert to an older version for any reason, which
 seems sensible.</p>
 <p>You can also remove the corresponding kernel headers too:</p>
-<div class="highlight"><pre>sudo apt-get purge linux-headers-x.x.x.x-generic
+<div class="highlight"><pre><span></span>sudo apt-get purge linux-headers-x.x.x.x-generic
 </pre></div>
 
 
@@ -249,18 +249,18 @@ this</a> while writing.&#160;<a class="footnote-backref" href="#fnref:2" rev="fo
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/stopping-windows-from-rebooting-at-the-bitlocker-boot-password-prompt.html
+++ b/posts/stopping-windows-from-rebooting-at-the-bitlocker-boot-password-prompt.html
@@ -119,7 +119,7 @@ password in time. This is apparently a problem if you have a UEFI install,
 which will be a common configuration these days.</p>
 <p>Having just tested this simple fix that I saw on <a href="https://social.technet.microsoft.com/Forums/office/en-US/932630c2-ae3d-4cbd-8d79-a492806363ea/windows-81-bitlocker-automatic-shutdown-during-password-prompt?forum=w8itproinstall">Microsoft's
 forums</a>:</p>
-<div class="highlight"><pre>bcdedit /set {bootmgr} bootshutdowndisabled 1
+<div class="highlight"><pre><span></span><span class="go">bcdedit /set {bootmgr} bootshutdowndisabled 1</span>
 </pre></div>
 
 
@@ -162,18 +162,18 @@ indefinitely.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/taking-control-of-chromium-and-chrome.html
+++ b/posts/taking-control-of-chromium-and-chrome.html
@@ -391,18 +391,18 @@ HTTPS Everywhere enables it for you.)</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/taking-web-page-screenshots-smartly-with-firefoxs-developer-tools.html
+++ b/posts/taking-web-page-screenshots-smartly-with-firefoxs-developer-tools.html
@@ -184,18 +184,18 @@ you've selected.)</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/the-case-of-a-windows-7-update-secure-boot-and-a-suspect-motherboard.html
+++ b/posts/the-case-of-a-windows-7-update-secure-boot-and-a-suspect-motherboard.html
@@ -278,18 +278,18 @@ Windows 10</a>.&#160;<a class="footnote-backref" href="#fnref:1" rev="footnote" 
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/the-death-of-desktop-pc.html
+++ b/posts/the-death-of-desktop-pc.html
@@ -247,18 +247,18 @@ is still an important one for computer enthusiasts.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/things-ive-learned-from-building-and.html
+++ b/posts/things-ive-learned-from-building-and.html
@@ -279,18 +279,18 @@ just built this PC, it's quite tempting to build one for myself...&#160;<a class
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/thinking-of-using-a-static-site-generator-for-your-blog.html
+++ b/posts/thinking-of-using-a-static-site-generator-for-your-blog.html
@@ -347,18 +347,18 @@ that Blogger ever did for my inspiration.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/types-of-data-scientist.html
+++ b/posts/types-of-data-scientist.html
@@ -227,18 +227,18 @@ ago</a> that
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/uninstalling-gotomeeting.html
+++ b/posts/uninstalling-gotomeeting.html
@@ -176,18 +176,18 @@ hadn't done a thing.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/updating-and-rooting-moto-g.html
+++ b/posts/updating-and-rooting-moto-g.html
@@ -182,7 +182,7 @@ useful reference.</p>
 <p>Boot into the bootloader using power on and volume down key (or enable
 USB debugging mode when the phone's on normally and do
 <code>adb reboot-bootloader</code>).</p>
-<div class="highlight"><pre>sudo fastboot flash partition gpt.bin
+<div class="highlight"><pre><span></span>sudo fastboot flash partition gpt.bin
 sudo fastboot flash motoboot motoboot.img
 sudo fastboot flash logo logo.bin
 sudo fastboot flash boot boot.img
@@ -216,17 +216,17 @@ version before the latest 4.4.4 update.)</p>
 firmware and upgrading, this didn't get relocked. </strong></p>
 <p>You need a bootloader unlock code from Motorola's
 <a href="https://motorola-global-portal.custhelp.com/app/standalone/bootloader/unlock-your-device-a">site</a>.</p>
-<div class="highlight"><pre>fastboot oem unlock
+<div class="highlight"><pre><span></span>fastboot oem unlock
 </pre></div>
 
 
 <p>Boot into fastboot mode: Enable developer mode again in settings:</p>
-<div class="highlight"><pre>adb reboot bootloader
+<div class="highlight"><pre><span></span>adb reboot bootloader
 </pre></div>
 
 
 <p>Optional: get a copy of the original Motorola logo and do:</p>
-<div class="highlight"><pre>sudo fastboot flash logo original_logo.bin
+<div class="highlight"><pre><span></span>sudo fastboot flash logo original_logo.bin
 </pre></div>
 
 
@@ -239,7 +239,7 @@ details.</p>
 <p>Get a recent fastboot .img; at the time of writing, 2.7.1.1 was the
 latest, but didn't work. 2.7.1.0 worked fine.</p>
 <p>Install through bootloader using fastboot:</p>
-<div class="highlight"><pre>sudo fastboot flash recovery modified_recovery.img
+<div class="highlight"><pre><span></span>sudo fastboot flash recovery modified_recovery.img
 </pre></div>
 
 
@@ -316,18 +316,18 @@ everything finally done. No more nagging for updates!</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/us-pycon-2014-talks.html
+++ b/posts/us-pycon-2014-talks.html
@@ -238,18 +238,18 @@ let me know! There's way too many to practically sit through.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/uses-for-a-raspberry-pi-part-1.html
+++ b/posts/uses-for-a-raspberry-pi-part-1.html
@@ -277,18 +277,18 @@ to be a great alternative to the BBC's officially supported service.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/uses-for-a-raspberry-pi-part-2.html
+++ b/posts/uses-for-a-raspberry-pi-part-2.html
@@ -177,14 +177,14 @@ periodically and download on any suitable matches.</p>
 guide</a>.
 Since then however, it's now much easier to install and maintain<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel="footnote">1</a></sup>,
 apparently you only need to enter this terminal command now:</p>
-<div class="highlight"><pre><span class="go">sudo apt-get install get-iplayer ffmpeg atomicparsley libmp3-info-perl</span>
+<div class="highlight"><pre><span></span><span class="go">sudo apt-get install get-iplayer ffmpeg atomicparsley libmp3-info-perl</span>
 </pre></div>
 
 
 <p>For convenience, I changed the default directory that <code>get_iplayer</code> saves
 in so that it was within a directory that was publically shared via
 Samba, using a command like</p>
-<div class="highlight"><pre><span class="go">./get_iplayer –-prefs-add –output=/home/shares/public/iPlayer</span>
+<div class="highlight"><pre><span></span><span class="go">./get_iplayer –-prefs-add –output=/home/shares/public/iPlayer</span>
 </pre></div>
 
 
@@ -192,7 +192,7 @@ Samba, using a command like</p>
 directory to whichever one <code>get_iplayer</code> is installed.)</p>
 <p><code>--prefs-add</code>, unsurprisingly, adds settings to the
 <code>get_iplayer</code> defaults. I also used this command:</p>
-<div class="highlight"><pre><span class="go">./get_iplayer --prefs-add --modes=best -–subtitles --subdir --nopurge</span>
+<div class="highlight"><pre><span></span><span class="go">./get_iplayer --prefs-add --modes=best -–subtitles --subdir --nopurge</span>
 </pre></div>
 
 
@@ -210,7 +210,7 @@ examples</a>
 in the documentation which is definitely worth a read and explains all
 the available options. A simple usage case would be to download all TV
 programmes that have "Top Gear" in the title or episode info:</p>
-<div class="highlight"><pre><span class="go">./get_iplayer --get &quot;Top Gear&quot;</span>
+<div class="highlight"><pre><span></span><span class="go">./get_iplayer --get &quot;Top Gear&quot;</span>
 </pre></div>
 
 
@@ -221,7 +221,7 @@ Alternatively, you could use <code>--type=tv,radio</code> and
 <code>get_iplayer</code> will search both the TV and radio programme lists.</p>
 <p>If there are several programmes with the same title (e.g. Newsnight),
 you can search for all programmes first by:</p>
-<div class="highlight"><pre><span class="go">./get_iplayer &quot;Newsnight&quot;</span>
+<div class="highlight"><pre><span></span><span class="go">./get_iplayer &quot;Newsnight&quot;</span>
 </pre></div>
 
 
@@ -229,13 +229,13 @@ you can search for all programmes first by:</p>
 this just now, it gave me several matches, but say that I wanted the
 broadcast from 01/07/2013. Among the nine matches this command gave me,
 it showed:</p>
-<div class="highlight"><pre>611: Newsnight - 01/07/2013, BBC Two, News, TV, default
+<div class="highlight"><pre><span></span>611: Newsnight - 01/07/2013, BBC Two, News, TV, default
 </pre></div>
 
 
 <p>I can then get that specific programme by just <code>--get</code>ting a
 programme number instead of a title:</p>
-<div class="highlight"><pre><span class="go">./get_iplayer --get 611</span>
+<div class="highlight"><pre><span></span><span class="go">./get_iplayer --get 611</span>
 </pre></div>
 
 
@@ -243,7 +243,7 @@ programme number instead of a title:</p>
 <p>Adding searches to the PVR is very similar to downloading available
 shows. As the documentation shows, instead of the <code>--get</code>
 option, you use <code>--pvr-add</code>:</p>
-<div class="highlight"><pre><span class="go">./get_iplayer --pvr-add=Top_Gear &quot;Top Gear&quot;</span>
+<div class="highlight"><pre><span></span><span class="go">./get_iplayer --pvr-add=Top_Gear &quot;Top Gear&quot;</span>
 </pre></div>
 
 
@@ -253,7 +253,7 @@ until the PVR searches are executed by the command:
 <code>./get_iplayer --pvr</code></p>
 <p>Supposing that we grew tired of Clarkson, Hammond and May's shenanigans,
 we can remove the PVR search entirely by <code>--pvr-del</code>:</p>
-<div class="highlight"><pre><span class="go">./get_iplayer --pvr-del=Top_Gear</span>
+<div class="highlight"><pre><span></span><span class="go">./get_iplayer --pvr-del=Top_Gear</span>
 </pre></div>
 
 
@@ -275,7 +275,7 @@ task scheduler</a>. Scheduling tasks by
 cron is carried out by entering <code>crontab -e</code> and then editing the file
 to start the job.`</p>
 <p>I had a problem where I could run the command</p>
-<div class="highlight"><pre><span class="go">get_iplayer --pvr</span>
+<div class="highlight"><pre><span></span><span class="go">get_iplayer --pvr</span>
 </pre></div>
 
 
@@ -314,7 +314,7 @@ the same directory.</p>
 <p>All the bbc_tracklist.py script needs to know is the programme id,
 which <code>get_iplayer</code> can pass through to it as <code>&lt;pid&gt;</code>. For
 example:</p>
-<div class="highlight"><pre><span class="go">./get_iplayer --get &quot;Gilles Peterson&quot; --type=radio --command &quot;/home/get_iplayer/bbc_tracklist.py &lt;pid&gt; &lt;dir&gt; &lt;fileprefix&gt;&quot;</span>
+<div class="highlight"><pre><span></span><span class="go">./get_iplayer --get &quot;Gilles Peterson&quot; --type=radio --command &quot;/home/get_iplayer/bbc_tracklist.py &lt;pid&gt; &lt;dir&gt; &lt;fileprefix&gt;&quot;</span>
 </pre></div>
 
 
@@ -323,7 +323,7 @@ tracklisting with the downloaded show) and a filename (to give the text
 file the same base filename). These are provided by <code>get_iplayer</code> via
 <code>&lt;dir&gt;</code> and <code>&lt;fileprefix&gt;</code>.</p>
 <p>It also works in the same way with PVR searches.</p>
-<div class="highlight"><pre><span class="go">./get_iplayer --pvr-add=Benji_B --type=radio &quot;Benji B&quot; --command &quot;/home/get_iplayer/bbc_tracklist.py &lt;pid&gt; &lt;dir&gt; &lt;fileprefix&gt;</span>
+<div class="highlight"><pre><span></span><span class="go">./get_iplayer --pvr-add=Benji_B --type=radio &quot;Benji B&quot; --command &quot;/home/get_iplayer/bbc_tracklist.py &lt;pid&gt; &lt;dir&gt; &lt;fileprefix&gt;</span>
 </pre></div>
 
 
@@ -402,18 +402,18 @@ upgrade</code>; my install is currently manually updated by running
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/using-garmin-forerunner-watches-with-linux.html
+++ b/posts/using-garmin-forerunner-watches-with-linux.html
@@ -169,7 +169,7 @@ changelog</a>.</p>
 to compile it from source. In Ubuntu, it was reasonably straightforward
 to clone it from <a href="https://github.com/gpsbabel/gpsbabel">GitHub</a> and then
 do the following:</p>
-<div class="highlight"><pre>./configure --prefix<span class="o">=</span><span class="nv">$HOME</span>/.local
+<div class="highlight"><pre><span></span>./configure --prefix<span class="o">=</span><span class="nv">$HOME</span>/.local
 make
 make install
 </pre></div>
@@ -179,13 +179,13 @@ make install
 directory</a> and avoids the need
 for <code>sudo</code> in <code>make install</code>.</p>
 <p>The only hiccup was that the <code>configure</code> step gave the error message:</p>
-<div class="highlight"><pre><span class="go">configure: error: Qt4 or Qt5 is required, but neither was found</span>
+<div class="highlight"><pre><span></span><span class="go">configure: error: Qt4 or Qt5 is required, but neither was found</span>
 </pre></div>
 
 
 <p><a href="https://stackoverflow.com/questions/16607003/qmake-could-not-find-a-qt-installation-of">The fix</a>
 was to do the following:</p>
-<div class="highlight"><pre>sudo apt-get install qtcreator
+<div class="highlight"><pre><span></span>sudo apt-get install qtcreator
 </pre></div>
 
 
@@ -194,7 +194,7 @@ compiling then worked. (I then removed <code>qtcreator</code> via <code>apt-get
 remove</code>.)</p>
 <h3>Converting Garmin's FIT data to GPX</h3>
 <p>An example use of GPSBabel is:</p>
-<div class="highlight"><pre>gpsbabel -i garmin_fit -f input.FIT -o gpx -F output.gpx
+<div class="highlight"><pre><span></span>gpsbabel -i garmin_fit -f input.FIT -o gpx -F output.gpx
 </pre></div>
 
 
@@ -319,18 +319,18 @@ user-replaceable. That drawback aside, it seems a decent choice.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/what-happens-when-github-decides-youre-not-a-human.html
+++ b/posts/what-happens-when-github-decides-youre-not-a-human.html
@@ -309,18 +309,18 @@ realm of DJ tools that work magnificently live.&#160;<a class="footnote-backref"
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/windows-10-installation-impressions.html
+++ b/posts/windows-10-installation-impressions.html
@@ -357,18 +357,18 @@ reinstall whichever extras for that game required it.&#160;<a class="footnote-ba
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/windows-update-locking-up-on-xp-when.html
+++ b/posts/windows-update-locking-up-on-xp-when.html
@@ -210,18 +210,18 @@ though...</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/working-with-multiple-ssh-keys-setting.html
+++ b/posts/working-with-multiple-ssh-keys-setting.html
@@ -134,7 +134,7 @@ separate Bitbucket directory and I don't think that the <code>ssh-agent</code> w
 automatically pick it up there, so I moved it back to the <code>.ssh</code>
 directory.)</p>
 <p>Add the following to <code>~/.ssh/config</code>:</p>
-<div class="highlight"><pre>Host github.com
+<div class="highlight"><pre><span></span>Host github.com
 User git
 IdentityFile ~/.ssh/id_rsa
 IdentitiesOnly yes
@@ -203,18 +203,18 @@ this unless you're an admin of the repository.&#160;<a class="footnote-backref" 
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/100.html
+++ b/tag/100.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/1204.html
+++ b/tag/1204.html
@@ -152,18 +152,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/academia.html
+++ b/tag/academia.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/academic.html
+++ b/tag/academic.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/activation.html
+++ b/tag/activation.html
@@ -130,18 +130,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ad.html
+++ b/tag/ad.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/adapter.html
+++ b/tag/adapter.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/adblock.html
+++ b/tag/adblock.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/advert.html
+++ b/tag/advert.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/aero.html
+++ b/tag/aero.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/airprint.html
+++ b/tag/airprint.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/anacron.html
+++ b/tag/anacron.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/analytics.html
+++ b/tag/analytics.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/android.html
+++ b/tag/android.html
@@ -270,18 +270,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/annoyance.html
+++ b/tag/annoyance.html
@@ -167,18 +167,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/app.html
+++ b/tag/app.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/article.html
+++ b/tag/article.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/assembly.html
+++ b/tag/assembly.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/asus.html
+++ b/tag/asus.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ata.html
+++ b/tag/ata.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/audio.html
+++ b/tag/audio.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/auto-patcher.html
+++ b/tag/auto-patcher.html
@@ -171,18 +171,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/backup.html
+++ b/tag/backup.html
@@ -181,18 +181,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bash.html
+++ b/tag/bash.html
@@ -150,18 +150,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/beat-grid.html
+++ b/tag/beat-grid.html
@@ -134,18 +134,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/beatmatching.html
+++ b/tag/beatmatching.html
@@ -169,18 +169,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/beautifulsoup.html
+++ b/tag/beautifulsoup.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/big.html
+++ b/tag/big.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bitbucket.html
+++ b/tag/bitbucket.html
@@ -159,18 +159,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bitlocker.html
+++ b/tag/bitlocker.html
@@ -280,18 +280,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/black.html
+++ b/tag/black.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/blocking.html
+++ b/tag/blocking.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/blog.html
+++ b/tag/blog.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/blogger.html
+++ b/tag/blogger.html
@@ -191,18 +191,18 @@ generators.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/blogging.html
+++ b/tag/blogging.html
@@ -173,18 +173,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bokeh.html
+++ b/tag/bokeh.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/book-review.html
+++ b/tag/book-review.html
@@ -132,18 +132,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/book.html
+++ b/tag/book.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/boot.html
+++ b/tag/boot.html
@@ -152,18 +152,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bug.html
+++ b/tag/bug.html
@@ -173,18 +173,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/build.html
+++ b/tag/build.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/business.html
+++ b/tag/business.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/cambridge.html
+++ b/tag/cambridge.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/career.html
+++ b/tag/career.html
@@ -210,18 +210,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/careers.html
+++ b/tag/careers.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/centrino.html
+++ b/tag/centrino.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/charging.html
+++ b/tag/charging.html
@@ -150,18 +150,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/chromium.html
+++ b/tag/chromium.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/citrix.html
+++ b/tag/citrix.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/clean.html
+++ b/tag/clean.html
@@ -152,18 +152,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/coding.html
+++ b/tag/coding.html
@@ -177,18 +177,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/communication.html
+++ b/tag/communication.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/connection.html
+++ b/tag/connection.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/convert.html
+++ b/tag/convert.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/course.html
+++ b/tag/course.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/coursera.html
+++ b/tag/coursera.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/cpu.html
+++ b/tag/cpu.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/cron.html
+++ b/tag/cron.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/data.html
+++ b/tag/data.html
@@ -272,18 +272,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/dban.html
+++ b/tag/dban.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/delay.html
+++ b/tag/delay.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/dependency.html
+++ b/tag/dependency.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/desktop.html
+++ b/tag/desktop.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/development.html
+++ b/tag/development.html
@@ -175,18 +175,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/device.html
+++ b/tag/device.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/digital.html
+++ b/tag/digital.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/disk.html
+++ b/tag/disk.html
@@ -171,18 +171,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/dj.html
+++ b/tag/dj.html
@@ -169,18 +169,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/dm-crypt.html
+++ b/tag/dm-crypt.html
@@ -152,18 +152,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/documentation.html
+++ b/tag/documentation.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/domain.html
+++ b/tag/domain.html
@@ -134,18 +134,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/draft.html
+++ b/tag/draft.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/drive.html
+++ b/tag/drive.html
@@ -220,18 +220,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/driver.html
+++ b/tag/driver.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/editing.html
+++ b/tag/editing.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/email.html
+++ b/tag/email.html
@@ -132,18 +132,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/enclosure.html
+++ b/tag/enclosure.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/encryption.html
+++ b/tag/encryption.html
@@ -257,18 +257,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/epson.html
+++ b/tag/epson.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/erase.html
+++ b/tag/erase.html
@@ -196,18 +196,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/error.html
+++ b/tag/error.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/expressions.html
+++ b/tag/expressions.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/external.html
+++ b/tag/external.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/firefox.html
+++ b/tag/firefox.html
@@ -184,18 +184,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/firmware.html
+++ b/tag/firmware.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/fix.html
+++ b/tag/fix.html
@@ -255,18 +255,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/fl.html
+++ b/tag/fl.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/folder.html
+++ b/tag/folder.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/foolishness.html
+++ b/tag/foolishness.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/forerunner.html
+++ b/tag/forerunner.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/fraction.html
+++ b/tag/fraction.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/free.html
+++ b/tag/free.html
@@ -152,18 +152,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/freeze.html
+++ b/tag/freeze.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/g300.html
+++ b/tag/g300.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/garmin.html
+++ b/tag/garmin.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/get_iplayer.html
+++ b/tag/get_iplayer.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/github.html
+++ b/tag/github.html
@@ -192,18 +192,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/gmail.html
+++ b/tag/gmail.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/golang.html
+++ b/tag/golang.html
@@ -132,18 +132,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/gotomeeting.html
+++ b/tag/gotomeeting.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/gps.html
+++ b/tag/gps.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/hdd.html
+++ b/tag/hdd.html
@@ -181,18 +181,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/hdparm.html
+++ b/tag/hdparm.html
@@ -161,18 +161,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/heartbleed.html
+++ b/tag/heartbleed.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/heatsink.html
+++ b/tag/heatsink.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/high.html
+++ b/tag/high.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/hog.html
+++ b/tag/hog.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/http-switchboard.html
+++ b/tag/http-switchboard.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/imagemagick.html
+++ b/tag/imagemagick.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/imap.html
+++ b/tag/imap.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ink.html
+++ b/tag/ink.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/install.html
+++ b/tag/install.html
@@ -173,18 +173,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/installation.html
+++ b/tag/installation.html
@@ -130,18 +130,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/intel.html
+++ b/tag/intel.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/iplayer.html
+++ b/tag/iplayer.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ipod.html
+++ b/tag/ipod.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/iso.html
+++ b/tag/iso.html
@@ -132,18 +132,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/jekyll.html
+++ b/tag/jekyll.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/job.html
+++ b/tag/job.html
@@ -245,18 +245,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/journal.html
+++ b/tag/journal.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/juniper.html
+++ b/tag/juniper.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/kernel.html
+++ b/tag/kernel.html
@@ -152,18 +152,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/key.html
+++ b/tag/key.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/keyboard.html
+++ b/tag/keyboard.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/keyword-search.html
+++ b/tag/keyword-search.html
@@ -132,18 +132,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/lag.html
+++ b/tag/lag.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/laptop.html
+++ b/tag/laptop.html
@@ -173,18 +173,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/latency.html
+++ b/tag/latency.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/leaky.html
+++ b/tag/leaky.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/learning.html
+++ b/tag/learning.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/led.html
+++ b/tag/led.html
@@ -150,18 +150,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/level.html
+++ b/tag/level.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/linux.html
+++ b/tag/linux.html
@@ -253,18 +253,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/logitech.html
+++ b/tag/logitech.html
@@ -150,18 +150,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/lts.html
+++ b/tag/lts.html
@@ -152,18 +152,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/lxml.html
+++ b/tag/lxml.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/mailinator.html
+++ b/tag/mailinator.html
@@ -132,18 +132,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/main.html
+++ b/tag/main.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/matplotlib.html
+++ b/tag/matplotlib.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/midi.html
+++ b/tag/midi.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/migration.html
+++ b/tag/migration.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/mock.html
+++ b/tag/mock.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/motherboard.html
+++ b/tag/motherboard.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/moto.html
+++ b/tag/moto.html
@@ -177,18 +177,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/mouse.html
+++ b/tag/mouse.html
@@ -150,18 +150,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/music.html
+++ b/tag/music.html
@@ -171,18 +171,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/musings.html
+++ b/tag/musings.html
@@ -130,18 +130,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/mx.html
+++ b/tag/mx.html
@@ -150,18 +150,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/name.html
+++ b/tag/name.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/namecheap.html
+++ b/tag/namecheap.html
@@ -134,18 +134,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/nano.html
+++ b/tag/nano.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/nature.html
+++ b/tag/nature.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/naturejobs.html
+++ b/tag/naturejobs.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/open.html
+++ b/tag/open.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/partition.html
+++ b/tag/partition.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pc.html
+++ b/tag/pc.html
@@ -177,18 +177,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pdf.html
+++ b/tag/pdf.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pdroid.html
+++ b/tag/pdroid.html
@@ -208,18 +208,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pelican.html
+++ b/tag/pelican.html
@@ -230,18 +230,18 @@ generators.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/phd.html
+++ b/tag/phd.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pi.html
+++ b/tag/pi.html
@@ -220,18 +220,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ping.html
+++ b/tag/ping.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/plot.html
+++ b/tag/plot.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/plugin.html
+++ b/tag/plugin.html
@@ -132,18 +132,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pop.html
+++ b/tag/pop.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/postdoc.html
+++ b/tag/postdoc.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/printer.html
+++ b/tag/printer.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/privacy.html
+++ b/tag/privacy.html
@@ -181,18 +181,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/production.html
+++ b/tag/production.html
@@ -171,18 +171,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/programming.html
+++ b/tag/programming.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/publishing.html
+++ b/tag/publishing.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pyc.html
+++ b/tag/pyc.html
@@ -134,18 +134,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pygtk.html
+++ b/tag/pygtk.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pypi.html
+++ b/tag/pypi.html
@@ -130,18 +130,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/python.html
+++ b/tag/python.html
@@ -440,18 +440,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/python2.html
+++ b/tag/python2.html
@@ -175,18 +175,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/quick-search.html
+++ b/tag/quick-search.html
@@ -132,18 +132,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/radio.html
+++ b/tag/radio.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/raspberry.html
+++ b/tag/raspberry.html
@@ -220,18 +220,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/raspbian.html
+++ b/tag/raspbian.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/red.html
+++ b/tag/red.html
@@ -150,18 +150,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/registrar.html
+++ b/tag/registrar.html
@@ -134,18 +134,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/regular.html
+++ b/tag/regular.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/remote.html
+++ b/tag/remote.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/research.html
+++ b/tag/research.html
@@ -210,18 +210,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/researcher.html
+++ b/tag/researcher.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/respawn.html
+++ b/tag/respawn.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/review.html
+++ b/tag/review.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/revolution.html
+++ b/tag/revolution.html
@@ -150,18 +150,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/rockbox.html
+++ b/tag/rockbox.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/root.html
+++ b/tag/root.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/running.html
+++ b/tag/running.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/samba.html
+++ b/tag/samba.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/schedule.html
+++ b/tag/schedule.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/science.html
+++ b/tag/science.html
@@ -235,18 +235,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/scikit-learn.html
+++ b/tag/scikit-learn.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/scraping.html
+++ b/tag/scraping.html
@@ -179,18 +179,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/screen.html
+++ b/tag/screen.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/screenshot.html
+++ b/tag/screenshot.html
@@ -130,18 +130,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/script.html
+++ b/tag/script.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/secure-boot.html
+++ b/tag/secure-boot.html
@@ -134,18 +134,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/secure.html
+++ b/tag/secure.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/security.html
+++ b/tag/security.html
@@ -177,18 +177,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/self-indulgence.html
+++ b/tag/self-indulgence.html
@@ -130,18 +130,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/server.html
+++ b/tag/server.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/shell.html
+++ b/tag/shell.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/site.html
+++ b/tag/site.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/slam.html
+++ b/tag/slam.html
@@ -150,18 +150,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/software.html
+++ b/tag/software.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/solution.html
+++ b/tag/solution.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/source.html
+++ b/tag/source.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/space.html
+++ b/tag/space.html
@@ -152,18 +152,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ssh.html
+++ b/tag/ssh.html
@@ -171,18 +171,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/startup.html
+++ b/tag/startup.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/static-site.html
+++ b/tag/static-site.html
@@ -139,18 +139,18 @@ generators.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/static.html
+++ b/tag/static.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/studio.html
+++ b/tag/studio.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/sync.html
+++ b/tag/sync.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/system.html
+++ b/tag/system.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/tablet.html
+++ b/tag/tablet.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/tag-cloud.html
+++ b/tag/tag-cloud.html
@@ -132,18 +132,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/tech.html
+++ b/tag/tech.html
@@ -144,18 +144,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/test.html
+++ b/tag/test.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/testing.html
+++ b/tag/testing.html
@@ -177,18 +177,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/theme.html
+++ b/tag/theme.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/thunderbird.html
+++ b/tag/thunderbird.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/tracklisting.html
+++ b/tag/tracklisting.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/traktor.html
+++ b/tag/traktor.html
@@ -169,18 +169,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/transfer.html
+++ b/tag/transfer.html
@@ -134,18 +134,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/trim.html
+++ b/tag/trim.html
@@ -152,18 +152,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/truecrypt.html
+++ b/tag/truecrypt.html
@@ -185,18 +185,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ublock.html
+++ b/tag/ublock.html
@@ -181,18 +181,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ubuntu.html
+++ b/tag/ubuntu.html
@@ -389,18 +389,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/uninstall.html
+++ b/tag/uninstall.html
@@ -136,18 +136,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/unit.html
+++ b/tag/unit.html
@@ -140,18 +140,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/university.html
+++ b/tag/university.html
@@ -210,18 +210,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/unrecognized.html
+++ b/tag/unrecognized.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/update.html
+++ b/tag/update.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/upgrade.html
+++ b/tag/upgrade.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/usb.html
+++ b/tag/usb.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/vacancy.html
+++ b/tag/vacancy.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/video.html
+++ b/tag/video.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/virtualenv.html
+++ b/tag/virtualenv.html
@@ -212,18 +212,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/vst.html
+++ b/tag/vst.html
@@ -146,18 +146,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/web.html
+++ b/tag/web.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/wifi.html
+++ b/tag/wifi.html
@@ -208,18 +208,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/windows.html
+++ b/tag/windows.html
@@ -378,18 +378,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/wireless.html
+++ b/tag/wireless.html
@@ -177,18 +177,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/wordpress.html
+++ b/tag/wordpress.html
@@ -249,18 +249,18 @@ generators.</p>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/xp.html
+++ b/tag/xp.html
@@ -148,18 +148,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/xprivacy.html
+++ b/tag/xprivacy.html
@@ -142,18 +142,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/youtube.html
+++ b/tag/youtube.html
@@ -138,18 +138,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tags.html
+++ b/tags.html
@@ -3236,18 +3236,18 @@ stevenmaude.co.uk            </a>
                         </a>
                     </li>
                     <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/fix">
-                            fix
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/job">
-                            job
+                        <a href="http://www.stevenmaude.co.uk/tag/linux">
+                            Linux
                         </a>
                     </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
+                        </a>
+                    </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/science">
+                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">


### PR DESCRIPTION
Using Python 3 and latest packages of dependencies where they're specified
(e.g. python-markdown, pygments).

This changes a few small things.

Some tag related things have changed; it doesn't worry me.

The refresh redirect pages have changed; not entirely sure why this didn't
happen previously, but consistent with the current pelican-alias that's
installed. Maybe I updated the repo to match upstream, but not the install I
had with Pelican.

pygments now adds random spans at the start of code blocks; this is a known
issue:
https://bitbucket.org/birkenfeld/pygments-main/issues/1254/empty-at-the-begining-of-the-highlight