### PR TITLE
Add ids to headers

### DIFF
--- a/archives.html
+++ b/archives.html
@@ -854,14 +854,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude.html
+++ b/author/steven-maude.html
@@ -356,14 +356,14 @@ watch was definitely a great budget choice.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude2.html
+++ b/author/steven-maude2.html
@@ -369,14 +369,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude3.html
+++ b/author/steven-maude3.html
@@ -416,14 +416,14 @@ generators.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude4.html
+++ b/author/steven-maude4.html
@@ -433,14 +433,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude5.html
+++ b/author/steven-maude5.html
@@ -447,14 +447,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude6.html
+++ b/author/steven-maude6.html
@@ -487,14 +487,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude7.html
+++ b/author/steven-maude7.html
@@ -465,14 +465,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude8.html
+++ b/author/steven-maude8.html
@@ -433,14 +433,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/author/steven-maude9.html
+++ b/author/steven-maude9.html
@@ -172,14 +172,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/authors.html
+++ b/authors.html
@@ -111,14 +111,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/categories.html
+++ b/categories.html
@@ -241,14 +241,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/2013.html
+++ b/category/2013.html
@@ -488,14 +488,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20132.html
+++ b/category/20132.html
@@ -472,14 +472,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20133.html
+++ b/category/20133.html
@@ -438,14 +438,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20134.html
+++ b/category/20134.html
@@ -202,14 +202,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/2014.html
+++ b/category/2014.html
@@ -434,14 +434,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20142.html
+++ b/category/20142.html
@@ -448,14 +448,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20143.html
+++ b/category/20143.html
@@ -243,14 +243,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/2015.html
+++ b/category/2015.html
@@ -332,14 +332,14 @@ generators.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/2016.html
+++ b/category/2016.html
@@ -357,14 +357,14 @@ watch was definitely a great budget choice.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/category/20162.html
+++ b/category/20162.html
@@ -282,14 +282,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/feeds/all.atom.xml
+++ b/feeds/all.atom.xml
@@ -21,7 +21,7 @@ your investment won't be ruined by using the watch in the rain, although
 it's not a swimming fitness watch. The battery life could be better, but
 I usually get several runs out of it from a full charge. And it should
 be capable of lasting for a marathon, even if I'm not yet.&lt;/p&gt;
-&lt;h2&gt;Connectivity&lt;/h2&gt;
+&lt;h2 id="connectivity"&gt;Connectivity&lt;/h2&gt;
 &lt;p&gt;Charging and data transfer are by USB only. There's no Bluetooth
 connectivity, but I prefer that there's no specific mobile or desktop
 application that I'm forced to use to get my data off the watch.&lt;/p&gt;
@@ -50,7 +50,7 @@ for a run, you'll need to occasionally press a button to keep the FR15
 awake before starting a run, otherwise the watch's power saving feature
 (which you can't disable) will turn it off. Not a huge deal, but not a
 perfect design either.&lt;/p&gt;
-&lt;h1&gt;Why wear a GPS watch while running?&lt;/h1&gt;
+&lt;h1 id="why-wear-a-gps-watch-while-running"&gt;Why wear a GPS watch while running?&lt;/h1&gt;
 &lt;p&gt;There's the slightly gimmicky thing of mapping runs and seeing how fast
 you were running. That said, having an archive of previous runs
 completed might be useful if you particularly enjoyed a route and want
@@ -108,7 +108,7 @@ source replacement firmware for audio players. Since then, Rockbox has
 become one of the open source projects that I use most. I've used it
 near daily on some device or other for probably around a decade, and I
 don't see that changing anytime soon.&lt;/p&gt;
-&lt;h2&gt;Easy listening&lt;/h2&gt;
+&lt;h2 id="easy-listening"&gt;Easy listening&lt;/h2&gt;
 &lt;p&gt;As an audio player is one of the things I'm using all the time, I like
 having a separate device with its own, usually lengthy, battery life.
 With that in mind, I'm probably a little ignorant if there's phone audio
@@ -123,7 +123,7 @@ is fully customisable should you wish to create your own.  Furthermore,
 if a device has the option of adding external media card storage, such
 as microSD, Rockbox sometimes goes beyond a device's official support,
 enabling the use of larger memory cards.&lt;/p&gt;
-&lt;h2&gt;Installing Rockbox&lt;/h2&gt;
+&lt;h2 id="installing-rockbox"&gt;Installing Rockbox&lt;/h2&gt;
 &lt;p&gt;If you want to give it a try, the first step is to take a look at the
 &lt;a href="https://rockbox.org"&gt;official site&lt;/a&gt; and see what devices are currently
 supported. It's also worth checking around the forums there too,
@@ -158,7 +158,7 @@ find-replace tool to patch the source to replace URLs that match, for
 example (but not limited to) http://download.rockbox.org to use HTTPS. I
 really should have submitted a patch but I couldn't face the hassle of
 creating a account to access Rockbox's Gerrit instance at the time.&lt;/p&gt;
-&lt;h2&gt;The future?&lt;/h2&gt;
+&lt;h2 id="the-future"&gt;The future?&lt;/h2&gt;
 &lt;p&gt;What's the long, long term future of the project? If you've hardware for
 which Rockbox is claimed to be stable, you'll probably find that's the
 case. I've had devices occasionally lock up, but these haven't happened
@@ -183,7 +183,7 @@ hardware becomes scarce and fewer new devices are designed and
 manufactured. In the meantime, it's nice to have software that does one
 thing and does it particularly well. As nothing better seems to have
 come along to usurp Rockbox's place, it's quite possible that I'll be
-using it over the next ten years as I have for the last ten.&lt;/p&gt;</summary><category term="open source"></category><category term="Rockbox"></category></entry><entry><title>Conversation conservation: recording audio input and output simultaneously in Linux</title><link href="http://www.stevenmaude.co.uk/posts/conversation-conservation-recording-audio-input-and-output-simultaneously-in-linux" rel="alternate"></link><published>2016-12-01T12:00:00+00:00</published><updated>2016-12-01T12:00:00+00:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-12-01:posts/conversation-conservation-recording-audio-input-and-output-simultaneously-in-linux</id><summary type="html">&lt;h2&gt;Why?&lt;/h2&gt;
+using it over the next ten years as I have for the last ten.&lt;/p&gt;</summary><category term="open source"></category><category term="Rockbox"></category></entry><entry><title>Conversation conservation: recording audio input and output simultaneously in Linux</title><link href="http://www.stevenmaude.co.uk/posts/conversation-conservation-recording-audio-input-and-output-simultaneously-in-linux" rel="alternate"></link><published>2016-12-01T12:00:00+00:00</published><updated>2016-12-01T12:00:00+00:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-12-01:posts/conversation-conservation-recording-audio-input-and-output-simultaneously-in-linux</id><summary type="html">&lt;h2 id="why"&gt;Why?&lt;/h2&gt;
 &lt;p&gt;Sometimes you might need to record both the audio playing out on your
 computer as well as an input. Often, this might be if you're recording a
 screencast or podcast, or if you want to record both sides of an online
@@ -193,7 +193,7 @@ for instance.&lt;/p&gt;
 what both of us were saying, without having to record both sides of the
 conversation separately and later try to combine them into a single
 piece of audio.&lt;/p&gt;
-&lt;h2&gt;How&lt;/h2&gt;
+&lt;h2 id="how"&gt;How&lt;/h2&gt;
 &lt;p&gt;The solution if you're using Linux and PulseAudio is &lt;a href="https://superuser.com/questions/769249/how-to-record-both-input-and-output-audio-simultaneously"&gt;mentioned
 here&lt;/a&gt;
 but I've clarified this below so I can find it quickly:&lt;/p&gt;
@@ -235,7 +235,7 @@ really, &lt;em&gt;really&lt;/em&gt; needed upgrading.&lt;/p&gt;
 &lt;p&gt;I'd been hesitant to upgrade. The last time I installed this way, it
 took a week of following several guides, many of them out of date or not
 working, and several failed installs.&lt;/p&gt;
-&lt;h2&gt;A quick guide&lt;/h2&gt;
+&lt;h2 id="a-quick-guide"&gt;A quick guide&lt;/h2&gt;
 &lt;p&gt;Fortunately, thanks to someone really helpful on the internet, I don't
 have to write much this time:&lt;/p&gt;
 &lt;ol&gt;
@@ -246,7 +246,7 @@ have to write much this time:&lt;/p&gt;
 &lt;p&gt;That's pretty much it.&lt;/p&gt;
 &lt;/li&gt;
 &lt;/ol&gt;
-&lt;h2&gt;Installing Windows&lt;/h2&gt;
+&lt;h2 id="installing-windows"&gt;Installing Windows&lt;/h2&gt;
 &lt;p&gt;Seeing as I have my text editor open, I'll clarify a little more.&lt;/p&gt;
 &lt;p&gt;To start with, I booted Windows 10 with my computer set to boot in UEFI
 mode and with Secure Boot enabled. Starting from a clean hard disk, when
@@ -284,7 +284,7 @@ BitLocker" should let you then go through the process of encrypting the
 drive.&lt;/p&gt;
 &lt;p&gt;Although I'm discussing Windows and Ubuntu here, note that the guide
 I've linked to may well work for two Linux installations too.&lt;/p&gt;
-&lt;h2&gt;Installing Ubuntu&lt;/h2&gt;
+&lt;h2 id="installing-ubuntu"&gt;Installing Ubuntu&lt;/h2&gt;
 &lt;p&gt;The usual advice is to install Linux &lt;em&gt;after&lt;/em&gt; Windows, since Windows
 doesn't necessarily play as nicely with Linux. I'm not sure if that
 still holds in the days of UEFI booting, but it seemed sensible to do.&lt;/p&gt;
@@ -325,7 +325,7 @@ the LUKS container. Depending on your UEFI setup and your preference,
 you may need to go into your PC's boot menu at startup and select Ubuntu
 directly (or reorder the default boot order so that it boots by
 default). &lt;/p&gt;
-&lt;h3&gt;Some more tips&lt;/h3&gt;
+&lt;h3 id="some-more-tips"&gt;Some more tips&lt;/h3&gt;
 &lt;p&gt;The guide's pretty good, and my install was successful first time with
 no real hiccups, which was a pleasant surprise. There are, however, a
 few points which aren't mentioned:&lt;/p&gt;
@@ -373,7 +373,7 @@ proceeding.&lt;/p&gt;
     inside your encrypted LUKS container.&lt;/p&gt;
 &lt;/li&gt;
 &lt;/ol&gt;
-&lt;h2&gt;Reinstalling&lt;/h2&gt;
+&lt;h2 id="reinstalling"&gt;Reinstalling&lt;/h2&gt;
 &lt;p&gt;How would reinstalling one of the operating systems work? I haven't
 tried it yet, so can't say for certain. Below is a thought experiment,
 although please heed the warning that it is only a thought experiment.&lt;/p&gt;
@@ -426,7 +426,7 @@ the lengthy page where I found them below, and discuss how to deal with
 &lt;p&gt;You can access hdparm by booting into, for example, an Ubuntu
 installation DVD or USB. Installing Linux isn't required: you can just
 "Try Ubuntu" instead which doesn't install anything at all.&lt;/p&gt;
-&lt;h2&gt;Safety first&lt;/h2&gt;
+&lt;h2 id="safety-first"&gt;Safety first&lt;/h2&gt;
 &lt;p&gt;First, the most sensible thing to do when erasing a drive is remove any
 drives other than those you wish to erase. It means even if you
 accidentally type the wrong thing that you won't erase a drive that you
@@ -439,7 +439,7 @@ Ctrl+Alt+T.&lt;/p&gt;
 
 &lt;p&gt;This will show you details of the disk, including the name. Replace the
 &lt;code&gt;/dev/sdX&lt;/code&gt; in the commands below with that name.&lt;/p&gt;
-&lt;h2&gt;Setting a password&lt;/h2&gt;
+&lt;h2 id="setting-a-password"&gt;Setting a password&lt;/h2&gt;
 &lt;p&gt;The next task is to set a password. I'm not sure that you really need to
 do this, but the
 &lt;a href="https://ata.wiki.kernel.org/index.php/ATA_Secure_Erase"&gt;kernel.org guide&lt;/a&gt;
@@ -467,7 +467,7 @@ be a simple fix.  First, check the drive's current status via:&lt;/p&gt;
 &lt;p&gt;and you may see "frozen",  as opposed to "not frozen", in the "Security"
 section of the &lt;code&gt;hdparm&lt;/code&gt; output. This means you can't change security
 settings, so attempting to set a password fails.&lt;/p&gt;
-&lt;h2&gt;Unfreezing&lt;/h2&gt;
+&lt;h2 id="unfreezing"&gt;Unfreezing&lt;/h2&gt;
 &lt;p&gt;In this case, the &lt;a href="https://superuser.com/questions/810867/new-ssd-hdparm-shows-frozen-whether-secure-erase-is-needed-before-installing"&gt;actual
 fix&lt;/a&gt;
 is simple. Suspending the PC, then powering it back on should then give
@@ -477,7 +477,7 @@ above again.&lt;/p&gt;
 &lt;code&gt;SECURITY_SET_PASS&lt;/code&gt; command without error. Also, rerunning the &lt;code&gt;hdparm
 -I&lt;/code&gt; command yet another time should show that a password is "enabled" as
 opposed to "not enabled".&lt;/p&gt;
-&lt;h2&gt;Erasing&lt;/h2&gt;
+&lt;h2 id="erasing"&gt;Erasing&lt;/h2&gt;
 &lt;p&gt;You can now proceed with the erase. If your drive's &lt;code&gt;hdparm&lt;/code&gt; output
 states &lt;code&gt;supported: enhanced erase&lt;/code&gt;, you could replace the
 &lt;code&gt;--security-erase&lt;/code&gt; below with &lt;code&gt;--security-erase-enhanced&lt;/code&gt;:&lt;/p&gt;
@@ -490,7 +490,7 @@ states &lt;code&gt;supported: enhanced erase&lt;/code&gt;, you could replace the
 enabled".&lt;/p&gt;</summary><category term="hdparm"></category><category term="erase"></category></entry><entry><title>Collecting disposable email with go-mailin8</title><link href="http://www.stevenmaude.co.uk/posts/collecting-disposable-email-with-go-mailin8" rel="alternate"></link><published>2016-11-12T21:47:00+00:00</published><updated>2016-11-12T21:47:00+00:00</updated><author><name>Steven Maude</name></author><id>tag:www.stevenmaude.co.uk,2016-11-12:posts/collecting-disposable-email-with-go-mailin8</id><summary type="html">&lt;p&gt;&lt;a href="https://github.com/StevenMaude/go-mailin8"&gt;go-mailin8&lt;/a&gt; is a command
 line utility I've created to get the most recent message from a
 Mailinator email inbox.&lt;/p&gt;
-&lt;h1&gt;What's Mailinator?&lt;/h1&gt;
+&lt;h1 id="whats-mailinator"&gt;What's Mailinator?&lt;/h1&gt;
 &lt;p&gt;&lt;a href="https://mailinator.com"&gt;Mailinator&lt;/a&gt; is one of a number of free services
 that allows you to use a disposable email address. This is handy when
 you're signing up for something but when you know that the account or
@@ -504,7 +504,7 @@ reducing the number of unwanted messages you receive. Yes, of course,
 you can usually unsubscribe from mailing lists, but that's extra work.
 Better to just not let the unwanted messages anywhere near your real
 inbox, where possible.&lt;/p&gt;
-&lt;h1&gt;Can't you just visit the site?&lt;/h1&gt;
+&lt;h1 id="cant-you-just-visit-the-site"&gt;Can't you just visit the site?&lt;/h1&gt;
 &lt;p&gt;Yes, you can. But I'm lazy, and this means switching to a new tab,
 visiting the URL and loading their home page, then entering the inbox
 address, loading the inbox page, and clicking the mail to display it and
@@ -517,7 +517,7 @@ local-part of the mailbox name (the part before the @):&lt;/p&gt;
 
 &lt;p&gt;and gives me back the most recent message. Copy-pasting the URL directly
 from the terminal is then simple.&lt;/p&gt;
-&lt;h1&gt;Why Go and not Python?&lt;/h1&gt;
+&lt;h1 id="why-go-and-not-python"&gt;Why Go and not Python?&lt;/h1&gt;
 &lt;p&gt;It would be probably have been easier to write in Python as I know that
 better than I do Go. But I'm conscious that I spent some time over the
 summer reading up on Go; the more chance to practise, the better.&lt;/p&gt;
@@ -540,7 +540,7 @@ website. And as there's now a new website, we don't really need to
 maintain the old one anymore. Just taking everything down would be a
 shame as there's lots of content on there that people have found
 useful in the past.&lt;/p&gt;
-&lt;h2&gt;WordPress migration&lt;/h2&gt;
+&lt;h2 id="wordpress-migration"&gt;WordPress migration&lt;/h2&gt;
 &lt;p&gt;Like many sites, it used WordPress. One option for migration away from
 WordPress is to export the content as an XML file, which either various
 other hosts may be able to import for you directly, or you can try
@@ -552,7 +552,7 @@ reuse the old content, which is a different task.&lt;/p&gt;
 a static one. However, none of the two I tried were successful; one just froze
 without seemingly doing anything, while the other only pulled a couple of pages
 from the site.&lt;/p&gt;
-&lt;h2&gt;Gathering the site content with &lt;code&gt;wget&lt;/code&gt;&lt;/h2&gt;
+&lt;h2 id="gathering-the-site-content-with-wget"&gt;Gathering the site content with &lt;code&gt;wget&lt;/code&gt;&lt;/h2&gt;
 &lt;p&gt;In the end, I resorted to &lt;a href="https://www.gnu.org/software/wget/"&gt;&lt;code&gt;wget&lt;/code&gt;&lt;/a&gt; which
 did an admirably good job after a few attempts.&lt;/p&gt;
 &lt;p&gt;&lt;code&gt;wget&lt;/code&gt; is more often known as a command-line download tool, but is much more
@@ -600,7 +600,7 @@ you require.&lt;/p&gt;
 simplicity. I think you could have done this using &lt;code&gt;--no-host-directories&lt;/code&gt;.&lt;/p&gt;
 &lt;p&gt;Running this command will then proceed to collect the content from the sites
 you've allowed it to crawl.&lt;/p&gt;
-&lt;h2&gt;Hosting for free&lt;/h2&gt;
+&lt;h2 id="hosting-for-free"&gt;Hosting for free&lt;/h2&gt;
 &lt;p&gt;If you have a free GitHub account and are competent enough with the
 basics of &lt;code&gt;git&lt;/code&gt;, note that you can host static sites, also for free, on
 GitHub Pages.  Introducing &lt;code&gt;git&lt;/code&gt; version control is an entirely other
@@ -612,15 +612,15 @@ to it, make commits and push them to a remote repository.&lt;/p&gt;
 controlled repository is that when you encounter things that need
 fixing, you can try them and always be able to restore to an earlier
 version, should you need to.&lt;/p&gt;
-&lt;h2&gt;Problems I had to solve&lt;/h2&gt;
-&lt;h3&gt;Broken links&lt;/h3&gt;
+&lt;h2 id="problems-i-had-to-solve"&gt;Problems I had to solve&lt;/h2&gt;
+&lt;h3 id="broken-links"&gt;Broken links&lt;/h3&gt;
 &lt;p&gt;Initially, the links to images or other pages were broken, the
 &lt;code&gt;--convert-links&lt;/code&gt; option fixed that.&lt;/p&gt;
-&lt;h3&gt;Unrestricted crawling&lt;/h3&gt;
+&lt;h3 id="unrestricted-crawling"&gt;Unrestricted crawling&lt;/h3&gt;
 &lt;p&gt;&lt;code&gt;wget&lt;/code&gt; was crawling other scraperwiki.com domains than the ones we wanted and
 collecting a lot of unnecessary content. All I needed was the main site, so I
 specified the domains to exclude.&lt;/p&gt;
-&lt;h3&gt;Removing dynamic features in the static site version&lt;/h3&gt;
+&lt;h3 id="removing-dynamic-features-in-the-static-site-version"&gt;Removing dynamic features in the static site version&lt;/h3&gt;
 &lt;p&gt;Some features of the site, as expected, no longer functioned after collecting
 the pages. For example, the comment and contact forms we had involve some
 processing on the WordPress server, and therefore were displayed on the static
@@ -642,7 +642,7 @@ a redirect from the old site: bots were presumably attempting to submit
 to a form on our new site, even though they were visiting the archive of
 the old site. (It was flagged by the form provider asking us to approve
 submissions from that URL.)&lt;/p&gt;
-&lt;h3&gt;Query strings in filenames&lt;/h3&gt;
+&lt;h3 id="query-strings-in-filenames"&gt;Query strings in filenames&lt;/h3&gt;
 &lt;p&gt;This was caused by WordPress hosting resources with version query
 strings in the URL, e.g.  CSS and JS. &lt;/p&gt;
 &lt;p&gt;When &lt;code&gt;wget&lt;/code&gt; retrieved the files initially, it retained the &lt;code&gt;?&lt;/code&gt; and the
@@ -675,18 +675,18 @@ was much more work to check.&lt;/p&gt;
 &lt;p&gt;Searching now, by far the simplest fix would be use a Wordpress plugin
 to remove the query strings before archiving. There are a couple out
 there.&lt;/p&gt;
-&lt;h3&gt;&lt;code&gt;srcset&lt;/code&gt; images&lt;/h3&gt;
+&lt;h3 id="srcset-images"&gt;&lt;code&gt;srcset&lt;/code&gt; images&lt;/h3&gt;
 &lt;p&gt;Some of our images were responsive &lt;code&gt;srcset&lt;/code&gt; images listed in &lt;code&gt;img&lt;/code&gt;
 attributes.  Until recently, &lt;code&gt;wget&lt;/code&gt; didn't handle this, but from &lt;code&gt;wget&lt;/code&gt;
 1.18, it supports &lt;code&gt;srcset&lt;/code&gt; images just as it does images in &lt;code&gt;src&lt;/code&gt;
 attributes of &lt;code&gt;img&lt;/code&gt; elements. To clarify, it both correctly retrieves
 the images &lt;em&gt;and&lt;/em&gt; updates the links. (I assume only when using
 &lt;code&gt;--convert-links&lt;/code&gt;.)&lt;/p&gt;
-&lt;h3&gt;Links in option values&lt;/h3&gt;
+&lt;h3 id="links-in-option-values"&gt;Links in option values&lt;/h3&gt;
 &lt;p&gt;As part of the site archive navigation, there were links to option
 values.  These weren't updated. I just hid those elements as it didn't
 seem a critical part of the site.&lt;/p&gt;
-&lt;h3&gt;WordPress emoji code&lt;/h3&gt;
+&lt;h3 id="wordpress-emoji-code"&gt;WordPress emoji code&lt;/h3&gt;
 &lt;p&gt;Recent versions of WordPress feature code to add emoji support for certain
 browsers. This embedded JavaScript is in the HTML and was still pulling from
 the old WordPress site because it contains an absolute URL within it. Saving
@@ -697,7 +697,7 @@ Emojis"&lt;/a&gt; plugin to the
 site, then recrawling.&lt;/p&gt;
 &lt;p&gt;It's not essential to fix this, but means the static site is not making
 requests for files that don't exist when you move from WordPress.&lt;/p&gt;
-&lt;h3&gt;Fixing up incorrect &lt;code&gt;index.html&lt;/code&gt; URLs&lt;/h3&gt;
+&lt;h3 id="fixing-up-incorrect-indexhtml-urls"&gt;Fixing up incorrect &lt;code&gt;index.html&lt;/code&gt; URLs&lt;/h3&gt;
 &lt;p&gt;Lots of URLs on the original site ended with &lt;code&gt;/&lt;/code&gt;, rather than
 &lt;code&gt;/some_page.html&lt;/code&gt;. &lt;code&gt;wget&lt;/code&gt; instead saved these pages with a filename of
 &lt;code&gt;index.html&lt;/code&gt;. Fixing these up was a pain. In terms of making the site
@@ -729,7 +729,7 @@ for the code I used.&lt;/p&gt;
 &lt;p&gt;There are a few other tweaks I did to clean up URL links too. They are
 detailed in the other &lt;a href="https://github.com/scraperwiki/scraperwiki-site-archive/commits/master"&gt;commit messages in the
 repository&lt;/a&gt;.&lt;/p&gt;
-&lt;h3&gt;Some other redirect problems&lt;/h3&gt;
+&lt;h3 id="some-other-redirect-problems"&gt;Some other redirect problems&lt;/h3&gt;
 &lt;p&gt;For us, some redirects we had set up on the old site caused a couple of cases
 where files ended up in the wrong place or with the wrong name compared with
 the original site. We had to be careful to fix up relative URLs here. We also
@@ -737,7 +737,7 @@ had multiple copies of certain files. These weren't difficult to fix by
 hand as there were only a few to modify.&lt;/p&gt;
 &lt;p&gt;Finally, we had to correctly set up redirects to the new site in our server
 configuration, and everything was finally done.&lt;/p&gt;
-&lt;h2&gt;Moving on&lt;/h2&gt;
+&lt;h2 id="moving-on"&gt;Moving on&lt;/h2&gt;
 &lt;p&gt;After much work, the static version's now working well. Everything's
 pretty much the same on &lt;a href="https://scraperwiki.com/"&gt;the site&lt;/a&gt; aside from
 the interactive forms. It was much more of a task to get done than I'd
@@ -787,13 +787,13 @@ won't require DNA proof of your humanity.&lt;/p&gt;
 automated systems, one short email later, it was politely resolved in
 ten minutes by GitHub's support team, who decided I was human after
 all.&lt;sup id="fnref:1"&gt;&lt;a class="footnote-ref" href="#fn:1" rel="footnote"&gt;1&lt;/a&gt;&lt;/sup&gt;&lt;/p&gt;
-&lt;h2&gt;What might have caused it?&lt;/h2&gt;
+&lt;h2 id="what-might-have-caused-it"&gt;What might have caused it?&lt;/h2&gt;
 &lt;p&gt;Perhaps creating several similar looking repositories (albeit with different
 code) in a relatively short space of time. These contain example code to access
 &lt;a href="https://github.com/pdftables"&gt;the API&lt;/a&gt; that we offer at work. Maybe it's
 because the commits looked similar, maybe because the commit messages or the
 commit content contained a URL. Who can say?&lt;/p&gt;
-&lt;h2&gt;Why is this not ideal?&lt;/h2&gt;
+&lt;h2 id="why-is-this-not-ideal"&gt;Why is this not ideal?&lt;/h2&gt;
 &lt;p&gt;Despite the quick resolution, the way this situation is handled might be
 flawed.&lt;/p&gt;
 &lt;p&gt;First, though the warning was omnipresent, large and red, it didn't describe
@@ -816,7 +816,7 @@ considers you a bot. There's no grace period where you can confirm your
 identity, before they hide your profile publically. It just gets hidden
 and, what I suspect happens is, the first you know of it is when it has
 been hidden.&lt;/p&gt;
-&lt;h2&gt;How might this cause problems?&lt;/h2&gt;
+&lt;h2 id="how-might-this-cause-problems"&gt;How might this cause problems?&lt;/h2&gt;
 &lt;p&gt;Let's say that you have a very high profile project under your GitHub account
 that lots of people rely on. Let's also suppose that this is the definitive
 installation source.&lt;/p&gt;
@@ -836,7 +836,7 @@ if there was some kind of short delay and an email warning before
 labelling your account as "not human", at least you'd have a chance to
 fix up your account first, without your account temporarily becoming a
 Ghost of GitHub Past.&lt;/p&gt;
-&lt;h2&gt;What's the relevance to other online services?&lt;/h2&gt;
+&lt;h2 id="whats-the-relevance-to-other-online-services"&gt;What's the relevance to other online services?&lt;/h2&gt;
 &lt;p&gt;This kind of situation isn't restricted specifically to GitHub. It does
 illustrate features of online services that are ever present, but remain
 latent until you encounter them. These are likely some variant of:&lt;/p&gt;
@@ -862,7 +862,7 @@ latent until you encounter them. These are likely some variant of:&lt;/p&gt;
   out because you don't even know what you did wrong.&lt;/p&gt;
 &lt;/li&gt;
 &lt;/ul&gt;
-&lt;h2&gt;More on GitHub&lt;/h2&gt;
+&lt;h2 id="more-on-github"&gt;More on GitHub&lt;/h2&gt;
 &lt;p&gt;OK, diversion aside, let's go back to speculating about GitHub accounts.
 Let's go further than hiding my account for a short time. What if my
 GitHub account was disabled entirely either for some period of time, or
@@ -952,7 +952,7 @@ issues. As far as I can tell, there's no separate checker you can run.
 If, like me, you disabled that annoying application, you'll want to
 re-enable it and see if there are any potential issues from any
 applications or hardware you have.&lt;/p&gt;
-&lt;h2&gt;Clean installation&lt;/h2&gt;
+&lt;h2 id="clean-installation"&gt;Clean installation&lt;/h2&gt;
 &lt;p&gt;Clean installation is a lot simpler than when Windows 10 was first
 launched, if you're claiming a free upgrade. Since the Threshold release
 last year, you can simply enter your existing Windows 7/8 product key,
@@ -962,7 +962,7 @@ installation solely to claim a digital entitlement, and then reinstall.&lt;/p&gt
 simple enough to navigate. Boot up the installer, select language
 options, choose where you want to install the operating system, wait a
 few minutes and you should soon have a working Windows install.&lt;/p&gt;
-&lt;h3&gt;Drivers&lt;/h3&gt;
+&lt;h3 id="drivers"&gt;Drivers&lt;/h3&gt;
 &lt;p&gt;In the past, even as recently as Windows 7, installing hardware was a
 mess in that you'd often have to trawl badly designed hardware
 manufacturer websites for several drivers you'd need to make everything
@@ -979,7 +979,7 @@ manufacturer, it was a particularly pleasant surprise to find that
 almost everything had been correctly installed. The main exception I
 found was a Native Instruments audio interface, but I realise that's not
 common hardware.&lt;/p&gt;
-&lt;h2&gt;Updates&lt;/h2&gt;
+&lt;h2 id="updates"&gt;Updates&lt;/h2&gt;
 &lt;p&gt;One of &lt;em&gt;the&lt;/em&gt; major drawbacks of Windows past is the update system. A
 fresh install of Windows 7 now requires in excess of two hundred
 updates, which greatly extends the time to complete the install. You'll
@@ -1015,7 +1015,7 @@ hours on my ancient Core2Duo PC. If this new method of rolling out
 updates avoids this, it will prevent much user frustration as the
 operating system gets older, particularly if, as Microsoft claim, this
 is the "last version" of Windows.&lt;/p&gt;
-&lt;h2&gt;Upgrade install&lt;/h2&gt;
+&lt;h2 id="upgrade-install"&gt;Upgrade install&lt;/h2&gt;
 &lt;p&gt;I'm not a huge fan of upgrade installs with Windows. Usually, if a full
 installation is warranted, enough time has passed that it's often
 worthwhile to do a clean install. In one case I dealt with, I felt it
@@ -1030,7 +1030,7 @@ You can download a USB creator or ISO from Microsoft's site, and run
 any problems following it. Microsoft do blatantly ignore your existing
 choice of browser and select Edge as the default for you though...
 thanks for that.&lt;/p&gt;
-&lt;h2&gt;And after installation?&lt;/h2&gt;
+&lt;h2 id="and-after-installation"&gt;And after installation?&lt;/h2&gt;
 &lt;p&gt;Despite it being out almost a year, I'm only really now starting to use
 Windows 10 on a regular basis. Where possible, I'd rather hold off if I
 have systems that are working well and let others find and report bugs.&lt;/p&gt;
@@ -1041,7 +1041,7 @@ versions of Windows. What you should be reading is this page on
 &lt;a href="https://technet.microsoft.com/en-us/itpro/windows/manage/configure-windows-telemetry-in-your-organization"&gt;Microsoft's site that details
 telemetry&lt;/a&gt;
 to tell you exactly what can be disabled.&lt;/p&gt;
-&lt;h3&gt;Other problems&lt;/h3&gt;
+&lt;h3 id="other-problems"&gt;Other problems&lt;/h3&gt;
 &lt;p&gt;Several other things I don't like have emerged over the few hours I've
 used Windows 10.&lt;/p&gt;
 &lt;ol&gt;
@@ -1108,7 +1108,7 @@ used Windows 10.&lt;/p&gt;
    still remains. Otherwise, changes made disappear once you log out.&lt;/p&gt;
 &lt;/li&gt;
 &lt;/ol&gt;
-&lt;h2&gt;But Windows 10 is worth a try&lt;/h2&gt;
+&lt;h2 id="but-windows-10-is-worth-a-try"&gt;But Windows 10 is worth a try&lt;/h2&gt;
 &lt;p&gt;That's a long list of complaints, but actually I'm more positive about
 Windows 10 than that might suggest. My near-decade old PC with an SSD
 boots Windows 10 in around twenty seconds from power on, which feels

--- a/index.html
+++ b/index.html
@@ -369,14 +369,14 @@ watch was definitely a great budget choice.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index2.html
+++ b/index2.html
@@ -382,14 +382,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index3.html
+++ b/index3.html
@@ -429,14 +429,14 @@ generators.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index4.html
+++ b/index4.html
@@ -446,14 +446,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index5.html
+++ b/index5.html
@@ -460,14 +460,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index6.html
+++ b/index6.html
@@ -500,14 +500,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index7.html
+++ b/index7.html
@@ -478,14 +478,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index8.html
+++ b/index8.html
@@ -446,14 +446,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/index9.html
+++ b/index9.html
@@ -185,14 +185,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/pages/contact-me.html
+++ b/pages/contact-me.html
@@ -140,14 +140,14 @@ here)stevenmaude.co.uk</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/52-weeks-52-posts.html
+++ b/posts/52-weeks-52-posts.html
@@ -186,14 +186,14 @@ I'm going to do things.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/a-beginners-guide-to-os-encryption-almost-2017-edition.html
+++ b/posts/a-beginners-guide-to-os-encryption-almost-2017-edition.html
@@ -125,7 +125,7 @@ really, <em>really</em> needed upgrading.</p>
 <p>I'd been hesitant to upgrade. The last time I installed this way, it
 took a week of following several guides, many of them out of date or not
 working, and several failed installs.</p>
-<h2>A quick guide</h2>
+<h2 id="a-quick-guide">A quick guide</h2>
 <p>Fortunately, thanks to someone really helpful on the internet, I don't
 have to write much this time:</p>
 <ol>
@@ -136,7 +136,7 @@ have to write much this time:</p>
 <p>That's pretty much it.</p>
 </li>
 </ol>
-<h2>Installing Windows</h2>
+<h2 id="installing-windows">Installing Windows</h2>
 <p>Seeing as I have my text editor open, I'll clarify a little more.</p>
 <p>To start with, I booted Windows 10 with my computer set to boot in UEFI
 mode and with Secure Boot enabled. Starting from a clean hard disk, when
@@ -174,7 +174,7 @@ BitLocker" should let you then go through the process of encrypting the
 drive.</p>
 <p>Although I'm discussing Windows and Ubuntu here, note that the guide
 I've linked to may well work for two Linux installations too.</p>
-<h2>Installing Ubuntu</h2>
+<h2 id="installing-ubuntu">Installing Ubuntu</h2>
 <p>The usual advice is to install Linux <em>after</em> Windows, since Windows
 doesn't necessarily play as nicely with Linux. I'm not sure if that
 still holds in the days of UEFI booting, but it seemed sensible to do.</p>
@@ -215,7 +215,7 @@ the LUKS container. Depending on your UEFI setup and your preference,
 you may need to go into your PC's boot menu at startup and select Ubuntu
 directly (or reorder the default boot order so that it boots by
 default). </p>
-<h3>Some more tips</h3>
+<h3 id="some-more-tips">Some more tips</h3>
 <p>The guide's pretty good, and my install was successful first time with
 no real hiccups, which was a pleasant surprise. There are, however, a
 few points which aren't mentioned:</p>
@@ -263,7 +263,7 @@ proceeding.</p>
     inside your encrypted LUKS container.</p>
 </li>
 </ol>
-<h2>Reinstalling</h2>
+<h2 id="reinstalling">Reinstalling</h2>
 <p>How would reinstalling one of the operating systems work? I haven't
 tried it yet, so can't say for certain. Below is a thought experiment,
 although please heed the warning that it is only a thought experiment.</p>
@@ -342,14 +342,14 @@ especially if you're running it as a desktop.&#160;<a class="footnote-backref" h
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/a-beginners-guide-to-os-encryption-dual.html
+++ b/posts/a-beginners-guide-to-os-encryption-dual.html
@@ -161,7 +161,7 @@ to follow them. (A note to anyone who kindly shares guides:
 way out of their depth.)</p>
 <p>Here's details of the three approaches I tested.</p>
 <hr />
-<h2>Approach 1: Encrypt Windows 8 Pro with Bitlocker; encrypt Ubuntu with <a href="https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup">LUKS</a></h2>
+<h2 id="approach-1-encrypt-windows-8-pro-with-bitlocker-encrypt-ubuntu-with-luks">Approach 1: Encrypt Windows 8 Pro with Bitlocker; encrypt Ubuntu with <a href="https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup">LUKS</a></h2>
 <p>I followed <a href="http://linuxtutorialscratchpad.blogspot.com/">this guide</a>
 with some success in that I was able to encrypt both systems.</p>
 <p>Instead of the Ubuntu minimal CD in those instructions, I used <a href="http://releases.ubuntu.com/precise/">Ubuntu
@@ -182,7 +182,7 @@ either. Even when Windows wasn't Bitlocker-encrypted, I was still
 getting these errors. I couldn't find much support for the problems I
 found, so perhaps it was some dual booting issue; if you have any ideas,
 please email or <a href="https://twitter.com/StevenMaude">let me know via Twitter</a>.</p>
-<h2>Approach 2: Encrypt Windows 7 Enterprise/Ultimate with Bitlocker; encrypt Ubuntu with LUKS</h2>
+<h2 id="approach-2-encrypt-windows-7-enterpriseultimate-with-bitlocker-encrypt-ubuntu-with-luks">Approach 2: Encrypt Windows 7 Enterprise/Ultimate with Bitlocker; encrypt Ubuntu with LUKS</h2>
 <p><img class="article-image" src="http://www.stevenmaude.co.uk/images/2013/Bitlocker.png" alt="Screengrab of Bitlocker's user interface in Windows 7."></p>
 <p>The first issue here is that the only versions of Windows 7 that support
 Bitlocker are Enterprise and Ultimate. If you have Windows 7 Pro, you're
@@ -201,7 +201,7 @@ might be possible to use a phone as USB storage...). If I was just lazy
 and just left it plugged in the whole time, it could easily be stolen
 with the PC. So, it was best that I didn't spend any more time
 considering this option.</p>
-<h2>Approach 3: Encrypt Windows 7 (any version) with TrueCrypt; encrypt Ubuntu with LUKS</h2>
+<h2 id="approach-3-encrypt-windows-7-any-version-with-truecrypt-encrypt-ubuntu-with-luks">Approach 3: Encrypt Windows 7 (any version) with TrueCrypt; encrypt Ubuntu with LUKS</h2>
 <p><img class="article-image" src="http://www.stevenmaude.co.uk/images/2013/TrueCrypt.png" alt="TrueCrypt program window showing options to create a new encrypted volume."></p>
 <div class="admonition article-edit">
 <p>Edit October 2015: There are vulnerabilities in the Windows
@@ -240,7 +240,7 @@ gave me the option to select UEFI or legacy mode at boot. Alternatively,
 and maybe more easily, <a href="http://askubuntu.com/questions/338894/how-to-disable-the-efi-check-in-13-04-x64">you can just delete the <code>efi</code> folder
 from the Ubuntu USB stick you
 prepare</a>.</p>
-<h2>Issues</h2>
+<h2 id="issues">Issues</h2>
 <p>In terms of usability, apart from having to enter another password
 before I boot either OS, everything seems pretty much as if the drives
 weren't encrypted. Otherwise, the only issues I have with this setup
@@ -259,7 +259,7 @@ are:</p>
     the event of loss or theft.</li>
 </ul>
 <p>All in all, not too bad.</p>
-<h2>SSD encryption?</h2>
+<h2 id="ssd-encryption">SSD encryption?</h2>
 <p>After all that effort, software encryption might not even be the best
 way to go. Instead, as SSDs have become more affordable, using
 hardware-based SSD encryption might be simpler. With the drive handling
@@ -337,14 +337,14 @@ concern</a>.&#160;<a class="footnote-backref" href="#fnref:1" rev="footnote" tit
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/a-year-of-garmin-a-forerunner-15-review.html
+++ b/posts/a-year-of-garmin-a-forerunner-15-review.html
@@ -137,7 +137,7 @@ your investment won't be ruined by using the watch in the rain, although
 it's not a swimming fitness watch. The battery life could be better, but
 I usually get several runs out of it from a full charge. And it should
 be capable of lasting for a marathon, even if I'm not yet.</p>
-<h2>Connectivity</h2>
+<h2 id="connectivity">Connectivity</h2>
 <p>Charging and data transfer are by USB only. There's no Bluetooth
 connectivity, but I prefer that there's no specific mobile or desktop
 application that I'm forced to use to get my data off the watch.</p>
@@ -166,7 +166,7 @@ for a run, you'll need to occasionally press a button to keep the FR15
 awake before starting a run, otherwise the watch's power saving feature
 (which you can't disable) will turn it off. Not a huge deal, but not a
 perfect design either.</p>
-<h1>Why wear a GPS watch while running?</h1>
+<h1 id="why-wear-a-gps-watch-while-running">Why wear a GPS watch while running?</h1>
 <p>There's the slightly gimmicky thing of mapping runs and seeing how fast
 you were running. That said, having an archive of previous runs
 completed might be useful if you particularly enjoyed a route and want
@@ -248,14 +248,14 @@ buying right now.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/android-device-encryption-is-mostly-good.html
+++ b/posts/android-device-encryption-is-mostly-good.html
@@ -196,14 +196,14 @@ definitely welcome.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/answers-to-some-windows-10-activation-questions.html
+++ b/posts/answers-to-some-windows-10-activation-questions.html
@@ -123,7 +123,7 @@ on a clean install of Windows 10 and successfully activate it.</p>
 worked and, probably because Threshold 2 is still fairly new, I couldn't
 find much to tell me how this was actually going to work out. Here's
 what I learned.</p>
-<h2>What happens if you clean install Windows 10 on a PC with an embedded Windows licence?</h2>
+<h2 id="what-happens-if-you-clean-install-windows-10-on-a-pc-with-an-embedded-windows-licence">What happens if you clean install Windows 10 on a PC with an embedded Windows licence?</h2>
 <p>These days, Windows licences for mass produced consumer systems are
 usually included in the BIOS itself, rather than printed on a sticker.</p>
 <p>What the Windows 10 install does is automatically installs and activates
@@ -134,7 +134,7 @@ licence, or Home if you had a Win 7/8 Home licence.)</p>
 entitlement rather than offered in perpetuity, so won't be an option
 once Microsoft's free upgrade offer expires in July 2016. You'll
 probably have to pay for an upgrade then.</p>
-<h2>Can you use a Windows 8/8.1 Pro Pack key to claim a Windows 10 Pro upgrade?</h2>
+<h2 id="can-you-use-a-windows-881-pro-pack-key-to-claim-a-windows-10-pro-upgrade">Can you use a Windows 8/8.1 Pro Pack key to claim a Windows 10 Pro upgrade?</h2>
 <p>Yes. You can go to "change product key" and try entering your key, but
 you'll probably see the error <code>0xc004f210</code>.</p>
 <p>This is because you're on Home, not Pro, so the key's not valid for that
@@ -151,7 +151,7 @@ licence which got upgraded to Windows 10 Home automatically on install.
 Then, I changed the product key to the generic Pro key. Following the
 Pro upgrade, the Windows 8 Pro Pack key that I'd previously used on the
 same laptop activated Windows 10 Pro.</p>
-<h2>Can you clean install Windows 10 Pro on a laptop which has an embedded Home licence?</h2>
+<h2 id="can-you-clean-install-windows-10-pro-on-a-laptop-which-has-an-embedded-home-licence">Can you clean install Windows 10 Pro on a laptop which has an embedded Home licence?</h2>
 <p>Once you've activated Windows 10, you get a digital entitlement. Any
 product key you first used to activate is no longer needed: in future,
 the Windows activation servers just check your hardware and see that you
@@ -173,7 +173,7 @@ you should get the Pro version installed.</p>
 <p>From there, you could enter your Windows 7/8 product key as described
 above or, if reinstalling, the digital entitlement should allow you to
 activate without entering any product key.</p>
-<h2>First impressions of Windows 10</h2>
+<h2 id="first-impressions-of-windows-10">First impressions of Windows 10</h2>
 <p>So far, I've noticed that the start menu is an improvement on Windows 8,
 but not as good as the one in Windows 7, the default theme is awful to
 look at compared with Windows 7's Aero — it's far too white and bright,
@@ -232,14 +232,14 @@ Windows 10 seemed stable enough.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/archiving-a-wordpress-site-with-wget-and-hosting-for-free.html
+++ b/posts/archiving-a-wordpress-site-with-wget-and-hosting-for-free.html
@@ -117,7 +117,7 @@ website. And as there's now a new website, we don't really need to
 maintain the old one anymore. Just taking everything down would be a
 shame as there's lots of content on there that people have found
 useful in the past.</p>
-<h2>WordPress migration</h2>
+<h2 id="wordpress-migration">WordPress migration</h2>
 <p>Like many sites, it used WordPress. One option for migration away from
 WordPress is to export the content as an XML file, which either various
 other hosts may be able to import for you directly, or you can try
@@ -129,7 +129,7 @@ reuse the old content, which is a different task.</p>
 a static one. However, none of the two I tried were successful; one just froze
 without seemingly doing anything, while the other only pulled a couple of pages
 from the site.</p>
-<h2>Gathering the site content with <code>wget</code></h2>
+<h2 id="gathering-the-site-content-with-wget">Gathering the site content with <code>wget</code></h2>
 <p>In the end, I resorted to <a href="https://www.gnu.org/software/wget/"><code>wget</code></a> which
 did an admirably good job after a few attempts.</p>
 <p><code>wget</code> is more often known as a command-line download tool, but is much more
@@ -177,7 +177,7 @@ you require.</p>
 simplicity. I think you could have done this using <code>--no-host-directories</code>.</p>
 <p>Running this command will then proceed to collect the content from the sites
 you've allowed it to crawl.</p>
-<h2>Hosting for free</h2>
+<h2 id="hosting-for-free">Hosting for free</h2>
 <p>If you have a free GitHub account and are competent enough with the
 basics of <code>git</code>, note that you can host static sites, also for free, on
 GitHub Pages.  Introducing <code>git</code> version control is an entirely other
@@ -189,15 +189,15 @@ to it, make commits and push them to a remote repository.</p>
 controlled repository is that when you encounter things that need
 fixing, you can try them and always be able to restore to an earlier
 version, should you need to.</p>
-<h2>Problems I had to solve</h2>
-<h3>Broken links</h3>
+<h2 id="problems-i-had-to-solve">Problems I had to solve</h2>
+<h3 id="broken-links">Broken links</h3>
 <p>Initially, the links to images or other pages were broken, the
 <code>--convert-links</code> option fixed that.</p>
-<h3>Unrestricted crawling</h3>
+<h3 id="unrestricted-crawling">Unrestricted crawling</h3>
 <p><code>wget</code> was crawling other scraperwiki.com domains than the ones we wanted and
 collecting a lot of unnecessary content. All I needed was the main site, so I
 specified the domains to exclude.</p>
-<h3>Removing dynamic features in the static site version</h3>
+<h3 id="removing-dynamic-features-in-the-static-site-version">Removing dynamic features in the static site version</h3>
 <p>Some features of the site, as expected, no longer functioned after collecting
 the pages. For example, the comment and contact forms we had involve some
 processing on the WordPress server, and therefore were displayed on the static
@@ -219,7 +219,7 @@ a redirect from the old site: bots were presumably attempting to submit
 to a form on our new site, even though they were visiting the archive of
 the old site. (It was flagged by the form provider asking us to approve
 submissions from that URL.)</p>
-<h3>Query strings in filenames</h3>
+<h3 id="query-strings-in-filenames">Query strings in filenames</h3>
 <p>This was caused by WordPress hosting resources with version query
 strings in the URL, e.g.  CSS and JS. </p>
 <p>When <code>wget</code> retrieved the files initially, it retained the <code>?</code> and the
@@ -252,18 +252,18 @@ was much more work to check.</p>
 <p>Searching now, by far the simplest fix would be use a Wordpress plugin
 to remove the query strings before archiving. There are a couple out
 there.</p>
-<h3><code>srcset</code> images</h3>
+<h3 id="srcset-images"><code>srcset</code> images</h3>
 <p>Some of our images were responsive <code>srcset</code> images listed in <code>img</code>
 attributes.  Until recently, <code>wget</code> didn't handle this, but from <code>wget</code>
 1.18, it supports <code>srcset</code> images just as it does images in <code>src</code>
 attributes of <code>img</code> elements. To clarify, it both correctly retrieves
 the images <em>and</em> updates the links. (I assume only when using
 <code>--convert-links</code>.)</p>
-<h3>Links in option values</h3>
+<h3 id="links-in-option-values">Links in option values</h3>
 <p>As part of the site archive navigation, there were links to option
 values.  These weren't updated. I just hid those elements as it didn't
 seem a critical part of the site.</p>
-<h3>WordPress emoji code</h3>
+<h3 id="wordpress-emoji-code">WordPress emoji code</h3>
 <p>Recent versions of WordPress feature code to add emoji support for certain
 browsers. This embedded JavaScript is in the HTML and was still pulling from
 the old WordPress site because it contains an absolute URL within it. Saving
@@ -274,7 +274,7 @@ Emojis"</a> plugin to the
 site, then recrawling.</p>
 <p>It's not essential to fix this, but means the static site is not making
 requests for files that don't exist when you move from WordPress.</p>
-<h3>Fixing up incorrect <code>index.html</code> URLs</h3>
+<h3 id="fixing-up-incorrect-indexhtml-urls">Fixing up incorrect <code>index.html</code> URLs</h3>
 <p>Lots of URLs on the original site ended with <code>/</code>, rather than
 <code>/some_page.html</code>. <code>wget</code> instead saved these pages with a filename of
 <code>index.html</code>. Fixing these up was a pain. In terms of making the site
@@ -306,7 +306,7 @@ for the code I used.</p>
 <p>There are a few other tweaks I did to clean up URL links too. They are
 detailed in the other <a href="https://github.com/scraperwiki/scraperwiki-site-archive/commits/master">commit messages in the
 repository</a>.</p>
-<h3>Some other redirect problems</h3>
+<h3 id="some-other-redirect-problems">Some other redirect problems</h3>
 <p>For us, some redirects we had set up on the old site caused a couple of cases
 where files ended up in the wrong place or with the wrong name compared with
 the original site. We had to be careful to fix up relative URLs here. We also
@@ -314,7 +314,7 @@ had multiple copies of certain files. These weren't difficult to fix by
 hand as there were only a few to modify.</p>
 <p>Finally, we had to correctly set up redirects to the new site in our server
 configuration, and everything was finally done.</p>
-<h2>Moving on</h2>
+<h2 id="moving-on">Moving on</h2>
 <p>After much work, the static version's now working well. Everything's
 pretty much the same on <a href="https://scraperwiki.com/">the site</a> aside from
 the interactive forms. It was much more of a task to get done than I'd
@@ -367,14 +367,14 @@ tips here might help you with your migration.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/arduous-lessons-in-python-why-main-is.html
+++ b/posts/arduous-lessons-in-python-why-main-is.html
@@ -132,7 +132,7 @@ everything was OK with my setup before I started.</p>
 lonely blinking cursor where I expected my test results.</p>
 <p>Something was happening, but none of the tests were seemingly running.
 That is, I wasn't seeing any pass/fail indicators, which was strange.</p>
-<h2>What actually happened</h2>
+<h2 id="what-actually-happened">What actually happened</h2>
 <p>Something was running that evidently wasn't what I intended.</p>
 <p>On inspection, one of the import statements in the test code had a
 structure somewhat like:</p>
@@ -159,7 +159,7 @@ they'll be called when you import it too.</p>
 <code>really_long_winded_scraping_function()</code> was being called. So, yes,
 eventually, the tests would have run, but they'd run <em>after</em> the code in
 the <code>import</code> had finished, which would have taken <strong>hours</strong>.</p>
-<h2>Fixing the problem</h2>
+<h2 id="fixing-the-problem">Fixing the problem</h2>
 <p>Normally, I routinely use:</p>
 <div class="highlight"><pre><span></span><span class="k">if</span> <span class="n">__name__</span> <span class="o">==</span> <span class="s1">&#39;__main__&#39;</span><span class="p">:</span>
     <span class="n">main</span><span class="p">()</span>
@@ -234,14 +234,14 @@ tests were the only other module that we'd imported the code into.)</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/as-easy-as-123-reg.html
+++ b/posts/as-easy-as-123-reg.html
@@ -115,7 +115,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Two factor or not two factor</h2>
+                <h2 id="two-factor-or-not-two-factor">Two factor or not two factor</h2>
 <p>We're living in the future right now: it's almost 2016. Almost as unbelievably,
 123-reg <em>still</em> haven't implemented any kind of two factor authentication for
 their site.</p>
@@ -159,7 +159,7 @@ modern, clean redesign.</p>
 was the quick response I received from Namecheap in resolving an issue when
 extending my domain name expiry. So, I started delving into the murky waters of
 domain transfers.</p>
-<h2>12(free)-reg</h2>
+<h2 id="12free-reg">12(free)-reg</h2>
 <p>When you dive in, you find the depths are actually not as bad as they first
 look. Certainly, the process isn't actually that complicated. The confusing
 part is navigating around help pages that usually tell an incomplete story of
@@ -171,7 +171,7 @@ changes on the old and new domain registrar's sites, and probably spent ten
 times that time reading around, and double and triple checking what I was
 doing. I didn't want to bungle the whole thing and spend hours in dialogue with
 support to resolve it.</p>
-<h2>Migrating .uk domains</h2>
+<h2 id="migrating-uk-domains">Migrating .uk domains</h2>
 <p>One important note is that .uk domains are handled a bit differently to others.
 The stages you need to carry out and avoid downtime aren't much more than:</p>
 <ol>
@@ -199,7 +199,7 @@ The stages you need to carry out and avoid downtime aren't much more than:</p>
 EPP authorisation code or lock status just doesn't apply at all for them.</p>
 <p>Also note by .uk domains, this is <em>any</em> .uk domain, i.e. this applies for
 stevenmaude.co.uk, not just stevenmaude.uk.</p>
-<h2>How to move from 123-reg to Namecheap</h2>
+<h2 id="how-to-move-from-123-reg-to-namecheap">How to move from 123-reg to Namecheap</h2>
 <ol>
 <li>
 <p>First, set up FreeDNS on Namecheap. Add your existing domain as detailed
@@ -336,14 +336,14 @@ domain is for use by a "UK Individual".</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/beatmatching-five-reasons-why-digital.html
+++ b/posts/beatmatching-five-reasons-why-digital.html
@@ -127,7 +127,7 @@ stevenmaude.co.uk            </a>
                 </div>
                 <p>2014/02/09: An edited version of this post was recently republished on
 <a href="http://www.djtechtools.com/2014/01/31/how-traktor-can-help-you-learn-to-beatmatch/">DJ TechTools</a>.</p>
-<h2>DJ software: complete with the kitsch in sync</h2>
+<h2 id="dj-software-complete-with-the-kitsch-in-sync">DJ software: complete with the kitsch in sync</h2>
 <p><img class="article-image" src="http://www.stevenmaude.co.uk/images/2014/sync.jpg" alt="Sync button from a Vestax VCI-100." width="400"></p>
 <p>There's a view — one I guess is primarily propagated by people who were DJing
 long before the likes of Traktor and Serato<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel="footnote">1</a></sup> came
@@ -150,7 +150,7 @@ Software's not really going to easily handle this for
 you<sup id="fnref:2"><a class="footnote-ref" href="#fn:2" rel="footnote">2</a></sup> as a lot of it is down to personal preference
 and choice, as well as the type of music you're playing. (Oh, sync is
 entirely optional too: no-one forces you to push that button.)</p>
-<h2>Why beatmatching is worth your time</h2>
+<h2 id="why-beatmatching-is-worth-your-time">Why beatmatching is worth your time</h2>
 <p>Having said all that, there are still good reasons why it's still worth
 learning:</p>
 <ol>
@@ -196,14 +196,14 @@ faded in. This is useful regardless of how you're beatmatching (e.g. for
 EQ purposes).</p>
 </li>
 </ol>
-<h2>What Traktor offers</h2>
+<h2 id="what-traktor-offers">What Traktor offers</h2>
 <p>Traktor has several features to aid beatmatching. If you're learning to
 do this manually, the natural inclination is to think, "OK, if I'm
 learning to do this myself, I shouldn't use any of these tools ." But,
 when you're learning to manually beatmatch, <strong>these features are still
 really useful</strong>. So what do we have?</p>
 <p><img class="article-image" src="http://www.stevenmaude.co.uk/images/2014/Traktor_layout.png" alt="Traktor deck showing sync button, phase meter and grid options with a BPM counter."></p>
-<h3>Phase meter</h3>
+<h3 id="phase-meter">Phase meter</h3>
 <p>You can practice with the phase meter to see how far off you are after
 you think you've beatmatched correctly, or just check how far off the
 beat you are when hitting play or scratching in a track. The phase meter
@@ -215,7 +215,7 @@ above, the track is over a quarter of a beat ahead.</p>
 otherwise the phase meter is likely to be misleading.)</em></p>
 <p>Of course, you can always use your ears for this, but the phase meter
 gives you a quick visual indication of how well you've done.</p>
-<h3>BPM counter</h3>
+<h3 id="bpm-counter">BPM counter</h3>
 <p>You can check BPMs immediately when you think you've matched tracks as
 well as possible<sup id="fnref:3"><a class="footnote-ref" href="#fn:3" rel="footnote">3</a></sup>. One easy way is just to click the
 GRID option directly below a deck (you can also add a permanent BPM
@@ -234,7 +234,7 @@ a BPM half or double what it should be, e.g. tracks at 140 BPM might be
 detected as 70. If the BPMs of the two tracks are reportedly wildly
 different, but you seem to have beatmatched them nonetheless, that's
 probably why.)</p>
-<h3>Sync</h3>
+<h3 id="sync">Sync</h3>
 <p>One exercise often mentioned in beginner beatmatching tutorials is to
 mix two identical tracks. When I was starting out, I found this sounds
 cluttered and confused me a little. Unsurprisingly, it's sometimes
@@ -249,14 +249,14 @@ sound like, the sync button will give you that too. You can then nudge
 one track slightly out of phase with the other using tempo bend to
 easily hear the difference, say, when a monitored track is ahead versus
 the live track; also useful in developing beatmatching skills.</p>
-<h3>Recording</h3>
+<h3 id="recording">Recording</h3>
 <p><img class="article-image" src="http://www.stevenmaude.co.uk/images/2014/Audio_recorder.png" alt="Traktor's audio recorder options."></p>
 <p>It's not always easy to judge how well your beatmatching is while you're
 actually doing it. Recording your practice and listening back to see how
 it actually sounds to a listener is pretty simple with one click. Are
 the beats matched together perfectly or not? Did you let the beats drift
 at all through a blend?</p>
-<h3>A comment on MIDI controllers</h3>
+<h3 id="a-comment-on-midi-controllers">A comment on MIDI controllers</h3>
 <p>One design choice that I would criticise about many MIDI controllers is
 that their pitch faders tend to be on the small side. This makes it
 difficult to accurately beatmatch, since precise adjustments (hundredths
@@ -264,7 +264,7 @@ of a BPM) are tricky. One workaround is to map a knob as a fine pitch
 control with a much smaller range.</p>
 <p>This lets you lock in to the rough BPM using the pitch fader, then use
 the knob to make very small corrections.</p>
-<h2>Summary</h2>
+<h2 id="summary">Summary</h2>
 <p><strong>As long as software doesn't perfectly get beatmatching correctly with
 zero preparation, there's still a need for beatmatching.</strong> Not only that,
 <em>software can actually help you practice and improve too: I self-taught
@@ -345,14 +345,14 @@ have been correctly beatgridded.&#160;<a class="footnote-backref" href="#fnref:3
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/beatmatching-to-beat-grid-in-traktor.html
+++ b/posts/beatmatching-to-beat-grid-in-traktor.html
@@ -115,7 +115,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Tracks that beat Traktor's beat detection</h2>
+                <h2 id="tracks-that-beat-traktors-beat-detection">Tracks that beat Traktor's beat detection</h2>
 <p>Traktor's not always perfect in automatic beat detection. I was trying to set
 the correct beats per minute (bpm) value for a particular track and not having
 a lot of luck with the tap function that Traktor provides. The estimated bpm
@@ -131,7 +131,7 @@ correctly.</p>
 stretch or compress the grid and correct it. Also, if you're zoomed in to precisely
 align this, you can't see if everything's still OK further along the track
 without going back and forth, like Cameo.</p>
-<h2>Beatmatching to find the bpm</h2>
+<h2 id="beatmatching-to-find-the-bpm">Beatmatching to find the bpm</h2>
 <p>The last time I was contemplating doing this I realised that if you can
 beatmatch by ear, then to find an unknown track's bpm, you can simply beatmatch
 to a track with a known good bpm. It's more fun too as you're actually
@@ -199,14 +199,14 @@ Ableton.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/beware-pythons-pyc-files.html
+++ b/posts/beware-pythons-pyc-files.html
@@ -168,14 +168,14 @@ your coding workflow.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/blogger-versus-wordpress-revisited.html
+++ b/posts/blogger-versus-wordpress-revisited.html
@@ -270,14 +270,14 @@ I'll describe the advantages of those in a later post.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/blogger-versus-wordpress.html
+++ b/posts/blogger-versus-wordpress.html
@@ -178,14 +178,14 @@ than just using a stock template.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/book-and-talk-review-making-music-74-creative-strategies-for-electronic-music-producers.html
+++ b/posts/book-and-talk-review-making-music-74-creative-strategies-for-electronic-music-producers.html
@@ -136,7 +136,7 @@ Here's what I took away from the insightful discussions then, much of
 which the book covers too. (For whatever reason, despite enjoying the
 talk, it took me a year to get around to reading the book, and you can
 find my view on it below the discussion of the session.)</p>
-<h2>How to approach that fresh, empty project file?</h2>
+<h2 id="how-to-approach-that-fresh-empty-project-file">How to approach that fresh, empty project file?</h2>
 <p>When all you have is nothing, making something from that can be
 difficult.</p>
 <p>It was mentioned that, if like Mozart, inspiration strikes <a href="http://www.brainpickings.org/2015/02/24/mozart-on-creativity/">when you go
@@ -157,7 +157,7 @@ creative phases is another approach. First, keep everything you make,
 then spend some time editing that ruthlessly. Remove anything that isn't
 great. You can repeat that until you have enough material to start
 building up a song.</p>
-<h2>Having too many tools to choose from</h2>
+<h2 id="having-too-many-tools-to-choose-from">Having too many tools to choose from</h2>
 <p>The problem of choice is one that surely almost everyone making music
 with computers has faced at some point. With a plethora of cheap or free
 VST plugins available, and settings for each one, it's possible to get
@@ -175,7 +175,7 @@ great electronic music decades ago with much more restrictive tools than
 those available to us today. DeSantis pointed out that you can go on
 looking for the perfect compression plugin, but no need to look further:
 you probably already have it in your collection.</p>
-<h2>Switching software to get out of creative dead ends</h2>
+<h2 id="switching-software-to-get-out-of-creative-dead-ends">Switching software to get out of creative dead ends</h2>
 <p>By contrast to focusing on certain tools you already have, switching
 digital audio workstation (DAW) completely was proposed — he candidly
 admitted that Ableton may not want him to say that. This sounds like a
@@ -190,7 +190,7 @@ instead.</p>
 solutions for sparking creativity, only suggestions. If an approach
 doesn't work, you need to try something else until you find something
 that works.</p>
-<h2>Actively listening to existing pieces for ideas</h2>
+<h2 id="actively-listening-to-existing-pieces-for-ideas">Actively listening to existing pieces for ideas</h2>
 <p>If you're a DJ, you're probably familiar with the idea that it can
 sometimes be more effective to align tracks at a higher level than just
 matching beats or, more commonly, bars (where the first beat of a
@@ -218,7 +218,7 @@ basis for your own work.</p>
 <p>When taking those elements outside of the context of that piece as
 inspiration, you're likely to end up with something that sounds distinct
 from the original work, rather than a poor imitation.</p>
-<h2>Knowing when a piece of music is complete</h2>
+<h2 id="knowing-when-a-piece-of-music-is-complete">Knowing when a piece of music is complete</h2>
 <p>On answering this, DeSantis cited an aphorism paraphrased as "art is
 never finished, only abandoned" (an internet search tells me this is
 often attributed to <a href="https://en.wikiquote.org/wiki/Paul_Val%C3%A9ry">Paul
@@ -243,7 +243,7 @@ creating as a career don't have that pressure. But you can still apply
 an informal deadline: perhaps aiming to finish a piece by a certain date
 or abandoning it otherwise could help you work with some time
 restriction in mind.</p>
-<h2>And how's the book?</h2>
+<h2 id="and-hows-the-book">And how's the book?</h2>
 <p>The <a href="https://makingmusic.ableton.com">sample</a> on Ableton's site is a
 sizeable and representative chunk of the entire book. That alone should
 an idea of whether you'd find it worthwhile, without me needing to tell
@@ -321,14 +321,14 @@ learners.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/book-review-data-science-for-business.html
+++ b/posts/book-review-data-science-for-business.html
@@ -218,14 +218,14 @@ if you want to check it out before buying.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/chatting-about-data-science-careers.html
+++ b/posts/chatting-about-data-science-careers.html
@@ -121,7 +121,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Visiting Cambridge</h2>
+                <h2 id="visiting-cambridge">Visiting Cambridge</h2>
 <p><img class="article-image" src="http://www.stevenmaude.co.uk/images/2014/Cambridge_1.jpg" alt="A photo of a street in Cambridge" width=300></p>
 <p>I visited Cambridge this week. Though I know Oxford fairly well, somehow
 I'd manage to avoid ever travelling to Cambridge before, so being in a
@@ -152,7 +152,7 @@ looking into data science as a career. And I'm also hoping that I
 managed to encourage those who, on speaking to them, seemed like they
 definitely had relevant skills, but they weren't entirely sure whether
 it was an option for them to explore.</p>
-<h2>PhDs moving from research to industry</h2>
+<h2 id="phds-moving-from-research-to-industry">PhDs moving from research to industry</h2>
 <p>There were two thoughts that I took away from the event. First, contrary
 to my preconceptions, it seemed that from the experiences of some of the
 other speakers that a long stay in university research wasn't perhaps as
@@ -259,14 +259,14 @@ interviews.&#160;<a class="footnote-backref" href="#fnref:3" rev="footnote" titl
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/close-to-edit-what-researchers-can.html
+++ b/posts/close-to-edit-what-researchers-can.html
@@ -235,14 +235,14 @@ page.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/collecting-disposable-email-with-go-mailin8.html
+++ b/posts/collecting-disposable-email-with-go-mailin8.html
@@ -115,7 +115,7 @@ stevenmaude.co.uk            </a>
                 <p><a href="https://github.com/StevenMaude/go-mailin8">go-mailin8</a> is a command
 line utility I've created to get the most recent message from a
 Mailinator email inbox.</p>
-<h1>What's Mailinator?</h1>
+<h1 id="whats-mailinator">What's Mailinator?</h1>
 <p><a href="https://mailinator.com">Mailinator</a> is one of a number of free services
 that allows you to use a disposable email address. This is handy when
 you're signing up for something but when you know that the account or
@@ -129,7 +129,7 @@ reducing the number of unwanted messages you receive. Yes, of course,
 you can usually unsubscribe from mailing lists, but that's extra work.
 Better to just not let the unwanted messages anywhere near your real
 inbox, where possible.</p>
-<h1>Can't you just visit the site?</h1>
+<h1 id="cant-you-just-visit-the-site">Can't you just visit the site?</h1>
 <p>Yes, you can. But I'm lazy, and this means switching to a new tab,
 visiting the URL and loading their home page, then entering the inbox
 address, loading the inbox page, and clicking the mail to display it and
@@ -142,7 +142,7 @@ local-part of the mailbox name (the part before the @):</p>
 
 <p>and gives me back the most recent message. Copy-pasting the URL directly
 from the terminal is then simple.</p>
-<h1>Why Go and not Python?</h1>
+<h1 id="why-go-and-not-python">Why Go and not Python?</h1>
 <p>It would be probably have been easier to write in Python as I know that
 better than I do Go. But I'm conscious that I spent some time over the
 summer reading up on Go; the more chance to practise, the better.</p>
@@ -196,14 +196,14 @@ computer nonetheless.)</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/conversation-conservation-recording-audio-input-and-output-simultaneously-in-linux.html
+++ b/posts/conversation-conservation-recording-audio-input-and-output-simultaneously-in-linux.html
@@ -115,7 +115,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Why?</h2>
+                <h2 id="why">Why?</h2>
 <p>Sometimes you might need to record both the audio playing out on your
 computer as well as an input. Often, this might be if you're recording a
 screencast or podcast, or if you want to record both sides of an online
@@ -125,7 +125,7 @@ for instance.</p>
 what both of us were saying, without having to record both sides of the
 conversation separately and later try to combine them into a single
 piece of audio.</p>
-<h2>How</h2>
+<h2 id="how">How</h2>
 <p>The solution if you're using Linux and PulseAudio is <a href="https://superuser.com/questions/769249/how-to-record-both-input-and-output-audio-simultaneously">mentioned
 here</a>
 but I've clarified this below so I can find it quickly:</p>
@@ -202,14 +202,14 @@ this unless you've already started recording.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/converting-pdfs-to-series-of-images.html
+++ b/posts/converting-pdfs-to-series-of-images.html
@@ -179,14 +179,14 @@ PDF</a> which is named
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/courseras-introduction-to-data-science.html
+++ b/posts/courseras-introduction-to-data-science.html
@@ -264,14 +264,14 @@ wouldn't hesitate to recommend it. Thanks to the staff for providing it!</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/dariks-boot-and-nuke-unrecognized.html
+++ b/posts/dariks-boot-and-nuke-unrecognized.html
@@ -207,14 +207,14 @@ in wiping the HDD, this isn't an issue.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/differences-between-working-in.html
+++ b/posts/differences-between-working-in.html
@@ -313,14 +313,14 @@ time was largely an easygoing one.&#160;<a class="footnote-backref" href="#fnref
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/ensuring-scheduled-cron-jobs-are-run.html
+++ b/posts/ensuring-scheduled-cron-jobs-are-run.html
@@ -155,7 +155,7 @@ However, when I checked the syslog with:</p>
 for this is that my Pi's not switched on long enough for the cron job to
 run.</strong> I usually leave it on for a couple of hours and then shutdown
 once I've finished with it.</p>
-<h2>Installing anacron is the solution!</h2>
+<h2 id="installing-anacron-is-the-solution">Installing anacron is the solution!</h2>
 <p>If you install anacron:
 <code>sudo apt-get
 install anacron</code>, you should find an
@@ -235,14 +235,14 @@ gave a very clear and helpful explanation of how the two interoperate.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/explaining-python-virtualenv-in-under.html
+++ b/posts/explaining-python-virtualenv-in-under.html
@@ -143,11 +143,11 @@ more, about <a href="http://www.vim.org/">vim</a>. However, David also showed me
 how to use virtualenv today. This was far easier for me to get my head
 round, so I'd figured I'd write up a quick start guide while it was
 fresh in mind.</p>
-<h2>What is virtualenv?</h2>
+<h2 id="what-is-virtualenv">What is virtualenv?</h2>
 <p>As the <a href="http://www.virtualenv.org/">homepage describes it</a>, "virtualenv
 is a tool to create isolated Python environments". These environments
 are also referred to as virtualenvs.</p>
-<h2>Why is this useful for software development?</h2>
+<h2 id="why-is-this-useful-for-software-development">Why is this useful for software development?</h2>
 <p>It greatly simplifies dependencies on other modules for different
 software projects you are working on. <em>Each virtualenv can have its own
 installed modules.</em> If projects require different versions of the same
@@ -165,10 +165,10 @@ is a substantial one.</p>
 <p>Another plus is that using virtualenvs stops you polluting your system's
 actual Python installation with lots of packages that you're using only
 to develop certain software.</p>
-<h2>How do you install it?</h2>
+<h2 id="how-do-you-install-it">How do you install it?</h2>
 <p>On Debian-based distributions, e.g. Ubuntu, you can use apt-get:
 <code>sudo apt-get install python-virtualenv</code></p>
-<h2>How do you use it?</h2>
+<h2 id="how-do-you-use-it">How do you use it?</h2>
 <p>In a terminal, make a directory for the project you're working on (or
 enter an existing directory), e.g. <code>newproject</code>. Creating a new virtualenv
 is as easy as entering <code>virtualenv newproject</code></p>
@@ -243,14 +243,14 @@ is a handy way to manage virtualenvs.)</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/explaining-python-virtualenvwrapper-in.html
+++ b/posts/explaining-python-virtualenvwrapper-in.html
@@ -128,7 +128,7 @@ you work on.</p>
 simplifies the use of virtualenvs! (Thanks
 <a href="https://twitter.com/morty_uk">Morty</a> for pointing it out!) Like my
 previous post, I'll keep any exposition to the minimum.</p>
-<h2>How do you install virtualenvwrapper?</h2>
+<h2 id="how-do-you-install-virtualenvwrapper">How do you install virtualenvwrapper?</h2>
 <p>On my Ubuntu 12.04 LTS system, I installed it via the apt package
 manager. It was a little bit more of a pain since it sticks it in a
 non-standard location:<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel="footnote">1</a></sup> not the expected
@@ -147,7 +147,7 @@ depending on where the virtualenvwrapper script is actually located.)</p>
 <p>Save your newly modified <code>.bashrc</code> and re-source it by entering in your
 bash terminal: <code>source ~/.bashrc</code></p>
 <p>virtualenvwrapper is now ready to go!</p>
-<h2>What does virtualenvwrapper offer?</h2>
+<h2 id="what-does-virtualenvwrapper-offer">What does virtualenvwrapper offer?</h2>
 <p>After using it briefly, the stand out features are:</p>
 <p><strong>List your available virtualenvs (provided they are located in
 <code>$WORKON_HOME</code>):</strong>
@@ -178,20 +178,20 @@ file in there. Add the following two lines to it:</p>
 with the path to your Python virtualenvs.</p>
 <p>Even in my case, where I only have a few projects right now, this
 shortcut saves you a lot of typing <code>cd</code> and <code>activate</code> commands.</p>
-<h3>Make a new virtualenv in $WORKON_HOME (this also activates it):</h3>
+<h3 id="make-a-new-virtualenv-in-workon_home-this-also-activates-it">Make a new virtualenv in $WORKON_HOME (this also activates it):</h3>
 <p><a href="http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html#mkvirtualenv"><code>mkvirtualenv newvirtualenvname</code></a></p>
-<h3>Delete a virtualenv:</h3>
+<h3 id="delete-a-virtualenv">Delete a virtualenv:</h3>
 <p><a href="http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html#rmvirtualenv"><code>rmvirtualenv virtualenvname</code></a></p>
-<h2>Other interesting virtualenv management features I've not used yet:</h2>
-<h3>Show installed packages in currently active virtualenv:</h3>
+<h2 id="other-interesting-virtualenv-management-features-ive-not-used-yet">Other interesting virtualenv management features I've not used yet:</h2>
+<h3 id="show-installed-packages-in-currently-active-virtualenv">Show installed packages in currently active virtualenv:</h3>
 <p><a href="http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html#lssitepackages"><code>lssitepackages</code></a></p>
-<h3>Wipe third party packages from the current virtualenv:</h3>
+<h3 id="wipe-third-party-packages-from-the-current-virtualenv">Wipe third party packages from the current virtualenv:</h3>
 <p><a href="http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html#wipeenv"><code>wipeenv</code></a></p>
-<h3>Add directories to the PYTHONPATH of the current virtualenv:</h3>
+<h3 id="add-directories-to-the-pythonpath-of-the-current-virtualenv">Add directories to the PYTHONPATH of the current virtualenv:</h3>
 <p><a href="http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html#add2virtualenv"><code>add2virtualenv directory1 directory2</code></a></p>
-<h3>Toggle the current virtualenv's access to your globally installed Python packages:</h3>
+<h3 id="toggle-the-current-virtualenvs-access-to-your-globally-installed-python-packages">Toggle the current virtualenv's access to your globally installed Python packages:</h3>
 <p><a href="http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html#toggleglobalsitepackages"><code>toggleglobalsitepackages</code></a></p>
-<h3>Run a command in all virtualenvs in WORKON_HOME:</h3>
+<h3 id="run-a-command-in-all-virtualenvs-in-workon_home">Run a command in all virtualenvs in WORKON_HOME:</h3>
 <p><a href="http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html#allvirtualenv"><code>allvirtualenv command</code></a></p>
 <p>There are further features <a href="http://virtualenvwrapper.readthedocs.org/">detailed in the
 documentation</a>, but these
@@ -252,14 +252,14 @@ standard location and should circumvent this problem entirely.)&#160;<a class="f
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/firefox-21-annoyances.html
+++ b/posts/firefox-21-annoyances.html
@@ -197,14 +197,14 @@ clicked, and then ignore it for no discernable reason.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/firefox-keyword-searches-and-how-to-fix-adding-them.html
+++ b/posts/firefox-keyword-searches-and-how-to-fix-adding-them.html
@@ -112,7 +112,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>What are keyword searches?</h2>
+                <h2 id="what-are-keyword-searches">What are keyword searches?</h2>
 <p>Keyword searches, or quick searches, are really handy when browsing. If
 you think of something that you want to search for, they remove the
 extra step of first navigating to the site and selecting the search box. </p>
@@ -121,14 +121,14 @@ preceded by some keyword. For instance, if I look up "Ubuntu" on
 <a href="https://duckduckgo.com">DuckDuckGo</a>, I can just hit Ctrl+L to access
 the address bar, type <code>d Ubuntu</code> and hit enter, to directly access the
 page of search results.</p>
-<h2>How keyword searches save time</h2>
+<h2 id="how-keyword-searches-save-time">How keyword searches save time</h2>
 <p>This might not seem like a big time saving, but when you consider that
 you have to repeat the same process for every site you search on, it
 soon adds up. It's a feature you can use not only with traditional
 search engines, but with most sites that have a search box. One example
 is YouTube, I'll often — maybe <strong>too</strong> often — type <code>yt Yet another timewasting
 distraction</code>.</p>
-<h2>Creating and using custom keyword searches in Firefox</h2>
+<h2 id="creating-and-using-custom-keyword-searches-in-firefox">Creating and using custom keyword searches in Firefox</h2>
 <p>This is really simple to do. You're really just adding a bookmark, but
 one that refers to whatever URL the search box will send you to, not the
 page itself.</p>
@@ -155,7 +155,7 @@ term. Hopefully you can see that if you construct the URL without even
 visiting the site first, that this should still work. That said, this
 assumes that the site uses GET requests where the query is contained in
 the URL itself.)</p>
-<h2>But my keyword searches aren't being added?</h2>
+<h2 id="but-my-keyword-searches-arent-being-added">But my keyword searches aren't being added?</h2>
 <p>As I find them so useful, I sorely missed it when recently, for whatever
 reason, Firefox decided that it wouldn't add them any more.</p>
 <p>The bookmark would get created, but the keyword I added didn't get
@@ -223,14 +223,14 @@ Firefox profiles.&#160;<a class="footnote-backref" href="#fnref:1" rev="footnote
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/fixing-chromium-on-ubuntu-video.html
+++ b/posts/fixing-chromium-on-ubuntu-video.html
@@ -176,14 +176,14 @@ remember.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/fixing-no-ink-levels-being-displayed-in.html
+++ b/posts/fixing-no-ink-levels-being-displayed-in.html
@@ -184,14 +184,14 @@ Utility</strong>.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/full-circle.html
+++ b/posts/full-circle.html
@@ -128,7 +128,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Blogger and blogging</h2>
+                <h2 id="blogger-and-blogging">Blogger and blogging</h2>
 <p>To me, it doesn't seem that long ago, but I wrote the first post on this
 blog ten months ago. Funnily enough, <a href="http://www.stevenmaude.co.uk/2013/05/blogger-versus-wordpress">it
 discussed</a>
@@ -150,7 +150,7 @@ about him considering migrating his <a href="http://drj11.wordpress.com/">Wordpr
 blog</a> to <a href="http://jekyllrb.com">Jekyll</a>, I
 had the inspiration of starting to write blog posts in Markdown and then
 converting them to HTML.</p>
-<h2>What's Markdown?</h2>
+<h2 id="whats-markdown">What's Markdown?</h2>
 <p>You might be asking that if you're not a developer. I hadn't heard of it
 at all before I started using GitHub, but I'm a convert now. It's a
 no-nonsense tool that converts plain text to HTML. Grab your drink of
@@ -165,7 +165,7 @@ tags.</p>
 <a href="http://johnmacfarlane.net/pandoc/">pandoc</a> that will convert Markdown
 to a host of other outputs too, e.g. PDF via LaTeX, Word docx,
 LibreOffice, even the epub ebook format.</p>
-<h2>What next?</h2>
+<h2 id="what-next">What next?</h2>
 <p>After finding that I prefer writing posts in Markdown, my next thought
 was: why not remove the middleman and use a system, like Jekyll, that
 directly uses Markdown?</p>
@@ -242,14 +242,14 @@ can deploy the site to GitHub Pages, then focus on writing again.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/getting-an-official-windows-10-disk-image.html
+++ b/posts/getting-an-official-windows-10-disk-image.html
@@ -116,7 +116,7 @@ stevenmaude.co.uk            </a>
 just getting hold of an official disk image. (I'm cautious these days and want
 to see how setting up a dual boot encrypted Windows 10/Ubuntu goes on a spare
 drive prior to actually committing to an upgrade.)</p>
-<h2>Start me up</h2>
+<h2 id="start-me-up">Start me up</h2>
 <p>The obvious searches for installing Windows 10 inevitably lead you to <a href="https://www.microsoft.com/en-gb/software-download/windows10">this
 page</a> where it
 tells you to install the Media Creation tool and use that.</p>
@@ -146,7 +146,7 @@ Microsoft account. The option to create a local account will be made available
 at the time of the final release.</p>
 </blockquote>
 <p>which was unclear as to whether this still applies or not.</p>
-<h2>Clean installing Windows 10</h2>
+<h2 id="clean-installing-windows-10">Clean installing Windows 10</h2>
 <p>The other question I had was which version, Home or Pro, gets installed from
 this single ISO. If it's a clean install, how is the version to install (Home
 or Pro) determined? From what I remember reading, the answer should be that if
@@ -194,14 +194,14 @@ installer prompts you to choose the version to install.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/heartbleed-ill-communication.html
+++ b/posts/heartbleed-ill-communication.html
@@ -186,14 +186,14 @@ better job in clarifying their position.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/hiding-draft-articles-in-pelican.html
+++ b/posts/hiding-draft-articles-in-pelican.html
@@ -123,7 +123,7 @@ writing more about how I migrated soon.</p>
 <p>As I approached the end of that lengthy migration, I found myself
 writing new draft articles that I wanted to ensure didn't actually make
 their way into my publication directory.</p>
-<h2>Writing blog posts</h2>
+<h2 id="writing-blog-posts">Writing blog posts</h2>
 <p>The way that I usually approach writing blog posts is that, as
 I reach the end of writing them, I'll start reading in the final display
 format, i.e. as a web page. This helps spot any mistakes that
@@ -134,7 +134,7 @@ publish while you still have draft articles in your <code>content</code> directo
 <p>Here's a few ways to prevent posts from being accidentally published,
 without needing to do file juggling of your drafts in and out of the
 <code>content</code> directory.</p>
-<h2>Marking as draft and <code>.gitignore</code></h2>
+<h2 id="marking-as-draft-and-gitignore">Marking as draft and <code>.gitignore</code></h2>
 <p>Any articles we stick in the <code>content</code> directory will end up in our
 <code>output</code> directory, right? Not if we do like
 <a href="http://docs.getpelican.com/en/latest/content.html">the documentation says</a>
@@ -147,12 +147,12 @@ on a post before you officially publish it.</p>
 if you're using <code>git</code> to push new versions of your blog for publication.
 Add <code>drafts/</code> to your <code>.gitignore</code> and you'd have to make a deliberate
 effort to add them for publication.</p>
-<h2>Stopping Pelican from seeing the draft posts</h2>
+<h2 id="stopping-pelican-from-seeing-the-draft-posts">Stopping Pelican from seeing the draft posts</h2>
 <p>The other option is to just prevent Pelican from seeing draft posts
 completely.</p>
 <p>This does mean that they won't appear in your local preview of your
 site, not even as an unlinked page.</p>
-<h3>Using Pelican's <code>IGNORE_FILES</code></h3>
+<h3 id="using-pelicans-ignore_files">Using Pelican's <code>IGNORE_FILES</code></h3>
 <p>Putting "draft" in the filename of any drafts is another option. Then,
 you can use the <code>IGNORE_FILES</code> setting in <code>pelicanconf.py</code> to
 specifically ignore the drafts.</p>
@@ -163,7 +163,7 @@ unintentionally change your configuration.</p>
 <p>For instance, the <a href="http://docs.getpelican.com/en/latest/settings.html">default</a>
 <code>IGNORE_FILES</code> setting is <code>IGNORE_FILES = ['.#*']</code> so we'll need to
 add <code>IGNORE_FILES = ['.#*', '*draft*']</code> to our Pelican settings.</p>
-<h3>Hiding the files completely (in Ubuntu, at least)</h3>
+<h3 id="hiding-the-files-completely-in-ubuntu-at-least">Hiding the files completely (in Ubuntu, at least)</h3>
 <p>Under Linux, I thought that preceding the filename with a dot would hide
 posts from Pelican, but it doesn't seem to. However, sticking a tilde on
 the end of the filename does seem to prevent Pelican from seeing the
@@ -214,14 +214,14 @@ Haven't tried this.)</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/horrible-wireless-network-pings-in.html
+++ b/posts/horrible-wireless-network-pings-in.html
@@ -228,14 +228,14 @@ you'd suffer a similar problem in Windows too otherwise.&#160;<a class="footnote
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-access-github-over-ssh-on-ubuntu.html
+++ b/posts/how-to-access-github-over-ssh-on-ubuntu.html
@@ -237,14 +237,14 @@ machines too.&#160;<a class="footnote-backref" href="#fnref:2" rev="footnote" ti
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-delete-directories-that-respawn.html
+++ b/posts/how-to-delete-directories-that-respawn.html
@@ -172,14 +172,14 @@ command</strong> to prevent the pesky thing returning again once and for all.</p
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-give-back-to-open-source-software.html
+++ b/posts/how-to-give-back-to-open-source-software.html
@@ -146,14 +146,14 @@ the past, I felt that I'd like to start making contributions back if I
 could. However, it may not be immediately obvious how you can get
 started, particularly if you're not a developer. Here are a few
 suggestions.</p>
-<h2>If you can code:</h2>
-<h3>Share your own projects</h3>
+<h2 id="if-you-can-code">If you can code:</h2>
+<h3 id="share-your-own-projects">Share your own projects</h3>
 <p>GitHub and Bitbucket both allow you to publish your own code as Git
 repositories, making them available to anyone. The sharing aspect aside,
 it also provides you with a public backup (incidentally, Bitbucket
 offers free private repositories too), and means that you can access
 your code from any computer with an internet connection.</p>
-<h3>Add features or fix bugs in other open source projects</h3>
+<h3 id="add-features-or-fix-bugs-in-other-open-source-projects">Add features or fix bugs in other open source projects</h3>
 <p><a href="https://help.github.com/articles/where-can-i-find-open-source-projects-to-work-on">GitHub
 suggest</a>
 that you look at popular or trending repositories which I guess may
@@ -166,13 +166,13 @@ small.</p>
 <p>If you're using existing software, you may well encounter issues
 yourself that you want to fix for your own use case. I think I'd find
 this more motivating than just trying to pick out some project</p>
-<h2>If you're not a developer:</h2>
+<h2 id="if-youre-not-a-developer">If you're not a developer:</h2>
 <p>From the outside looking in, it's easy to think along the lines of,
 "software is code, so if I can't code, I can't contribute". That
 couldn't be more wrong. There's much more to software projects than just
 the code, and there are still valuable ways for you to contribute that
 would be no less appreciated by the owners of a project.</p>
-<h3>Write or translate</h3>
+<h3 id="write-or-translate">Write or translate</h3>
 <p>At a very basic level, submitting documentation fixes or improvements is
 a great help as it helps other users get started. If no documentation,
 start writing some! If you speak other languages, the developers may
@@ -186,7 +186,7 @@ the project's repository under your account.</p>
 then click "Send pull request" on the next page. The owner of the
 project will be notified that you've suggested some changes, which they
 can easily pull back into their project from their copy.</p>
-<h3>Raise issues</h3>
+<h3 id="raise-issues">Raise issues</h3>
 <p>While you're using an open source project, you might spot a bug or think
 of something which would make a neat feature. If you check the available
 issue trackers for anyone mentioning something similar and don't find
@@ -199,10 +199,10 @@ contacted me via GitHub's issue tracker to say that it shouldn't just
 save them to text files, but it should also tag the audio file too. This
 was something I hadn't thought of, but it seemed a nifty feature so I
 was happy to work on adding it as I felt it improved the software.</p>
-<h3>Design</h3>
+<h3 id="design">Design</h3>
 <p>Maybe a project is looking for designers, for assets in the software
 (e.g. icons) or for their website?</p>
-<h3>Contribute to the community</h3>
+<h3 id="contribute-to-the-community">Contribute to the community</h3>
 <p>Is there a piece of open source software that you know a lot about? Can
 you help out other users questions on an official forum, user group or
 mailing list, or somewhere on the Stack Exchange sites?</p>
@@ -212,7 +212,7 @@ week, I discovered <a href="http://waveshop.sourceforge.net/">waveshop</a> which
 a lightweight audio editor (more so than Audacity) thanks to this post
 on
 <a href="http://www.kvraudio.com/forum/viewtopic.php?f=7&amp;t=405650&amp;sid=290141ba72f888578036b63bf6bd3981">kvraudio</a></p>
-<h3>Donate</h3>
+<h3 id="donate">Donate</h3>
 <p>Some open source projects have contributions made by paid employees, but
 many projects are developed by enthusiasts without any funding and in
 their free time, so money must be a good thing, right?</p>
@@ -225,7 +225,7 @@ sufficient money may be enough to hire developers or allow people to
 quit their day jobs to work on projects.)</p>
 <p>In some cases, certainly, developers may well <a href="http://www.rockbox.org/wiki/DonatedMoney">welcome donations to
 acquire hardware for testing</a>.</p>
-<h2>Conclusion</h2>
+<h2 id="conclusion">Conclusion</h2>
 <p>There are plenty of ways to get involved. The next time you're
 downloading an open source project, maybe consider taking a look around
 their web pages or their repositories to see if there's anything you can
@@ -271,14 +271,14 @@ help with.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-secure-your-storage-and-backup.html
+++ b/posts/how-to-secure-your-storage-and-backup.html
@@ -141,7 +141,7 @@ spent</a>
 encrypting operating system drives, it's a relief that encrypting
 non-system drives is far, far simpler.</p>
 <p><img class="article-image" src="http://www.stevenmaude.co.uk/images/2013/Bitlocker_context_menu.png" alt="Bitlocker drive context menu."></p>
-<h2>Bitlocker</h2>
+<h2 id="bitlocker">Bitlocker</h2>
 <p>If only using Windows, and provided your copy of Windows is bundled with
 it, you could use Bitlocker. Bitlocker is straightforward to setup with
 self-explanatory instructions.</p>
@@ -153,7 +153,7 @@ a recovery key in case you forget your password. All that's left is to
 encrypt the drive by finally choosing to Start Encryption.</p>
 <p>The next time you insert the drive, it will prompt you for the password
 to unlock it. Enter it and the drive functions just as normal.</p>
-<h3>Issues with Bitlocker</h3>
+<h3 id="issues-with-bitlocker">Issues with Bitlocker</h3>
 <p>Note that you'll need to use Microsoft's <a href="http://windows.microsoft.com/en-us/windows7/what-is-the-bitlocker-to-go-reader">Bitlocker To Go
 Reader</a>
 for <strong>read-only access</strong> to Bitlocker-encrypted drives in older Windows
@@ -173,7 +173,7 @@ writing).</p>
 <p>Update 2: USB 3 works fine, but there's <a href="http://www.stevenmaude.co.uk/2013/10/odd-behaviour-of-bitlocker-or-maybe-my">some weird Bitlocker or drive
 specific issue
 behaviour</a>...</p>
-<h2>TrueCrypt</h2>
+<h2 id="truecrypt">TrueCrypt</h2>
 <div class="admonition article-edit">
 <p>Edit: see my <a href="http://www.stevenmaude.co.uk/a-beginners-guide-to-os-encryption-dual.html#fn:2">earlier encryption
 post</a>
@@ -216,7 +216,7 @@ files on it. When you've finished working with the drive, you should
 select it in TrueCrypt and choose Dismount. You can then safely eject
 the drive from Windows as you would normally, and then remove it from
 your PC.</p>
-<h3>Issues with TrueCrypt</h3>
+<h3 id="issues-with-truecrypt">Issues with TrueCrypt</h3>
 <p>The only requirement is that you need TrueCrypt to be running on a
 destination PC. This can either be via having it installed to the PC
 directly, or, for Windows PCs at least, having access to an appropriate
@@ -231,7 +231,7 @@ privileges since it requires them to mount a drive.) With Bitlocker,
 non-admins can access drives without any issue (aside from older Windows
 version needing the reader application ), and this might factor into
 your choice of encryption software.</p>
-<h2>Encrypting backup drives</h2>
+<h2 id="encrypting-backup-drives">Encrypting backup drives</h2>
 <p>If you're encrypting everything else, it probably makes sense to
 considering encrypting your backups too. If your system is already
 encrypted completely, you could simply clone the entire drive with
@@ -241,14 +241,14 @@ a drive's been encrypted with TrueCrypt, though <a href="http://superuser.com/qu
 is fine</a>.</p>
 <p>Using the backup tools provided by each individual OS is also an
 option.</p>
-<h3>Windows</h3>
+<h3 id="windows">Windows</h3>
 <p>Windows Backup and Restore <a href="http://superuser.com/questions/126111/how-can-you-use-windows-backup-with-a-truecrypt-encrypted-backup-destination">needs slightly awkward
 workarounds</a>
 to function with TrueCrypt drives; however, Bitlocker encrypted external
 drives work seamlessly with this feature. The File History feature in
 Windows 8 should work fine with TrueCrypt drives, on the other hand (it
 doesn't use Volume Shadow Copy that TrueCrypt is incompatible with).</p>
-<h3>Ubuntu</h3>
+<h3 id="ubuntu">Ubuntu</h3>
 <p>For Ubuntu, I'm using the built-in Backup tool (Déjà Dup) which is based
 on <a href="http://duplicity.nongnu.org/">Duplicity</a>. At its core, this backup
 tool is very much end-user focused. It's incredibly simple to set up.
@@ -268,7 +268,7 @@ encryption
 yourself</a>),
 but Déjà Dup gave me a fuss-free way to get an encrypted backup running,
 which I really like.</p>
-<h2>Summary</h2>
+<h2 id="summary">Summary</h2>
 <p>If you're carrying around sensitive or personal data on portable drives,
 it's worth taking the time to make sure that the data's secure in case
 you lose the drive. It's simple to setup regardless of whichever OS
@@ -314,14 +314,14 @@ you're using.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-to-use-mock-in-python-to-mock.html
+++ b/posts/how-to-use-mock-in-python-to-mock.html
@@ -122,7 +122,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Testing</h2>
+                <h2 id="testing">Testing</h2>
 <p>Testing is a useful programming practice which, in all honesty, I'm
 still learning much about. Tests can give you some reassurance as to the
 behaviour of your code, providing you've written your tests such that
@@ -137,7 +137,7 @@ one he <a href="http://nedbatchelder.com/text/st.html">recently</a> gave. In the
 latter, he covers testing from the ground up. The former is a little
 less introductory, but is a good complimentary talk; he works through a
 few examples where writing tests can give a better organisation to code.</p>
-<h2>Testing and me</h2>
+<h2 id="testing-and-me">Testing and me</h2>
 <p>My problems in creating tests are often two-fold. First, I'm not always
 sure what are good tests to write - for instance, unit tests should be
 isolated, but how much should I be mocking out in unit tests? For some
@@ -161,7 +161,7 @@ I often encounter: how to actually implement tests. Often, I'll find I
 know what I want to achieve but find difficulty in actually articulating
 this in code, usually because I've not found the functions I want in
 <code>mock</code>.</p>
-<h2>Mocking a method of an object with Python <code>mock</code></h2>
+<h2 id="mocking-a-method-of-an-object-with-python-mock">Mocking a method of an object with Python <code>mock</code></h2>
 <p>Anyway, here's an example of this which might be useful if you're trying
 to do something similar. In this case, I wanted to test a method of an
 object, but wasn't sure how to do that using a mock.</p>
@@ -277,14 +277,14 @@ I'll be much quicker to get something going.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/how-universities-can-help-develop.html
+++ b/posts/how-universities-can-help-develop.html
@@ -169,8 +169,8 @@ careers, to writing CVs and cover letters, to networking and other job
 search approaches, to interviews. Given that comprehensive coverage of
 job searching, the title the course had ("Career Architect") certainly
 wasn't unreasonable.</p>
-<h2>Why did this approach work so well?</h2>
-<h3>1. It provided time to think.</h3>
+<h2 id="why-did-this-approach-work-so-well">Why did this approach work so well?</h2>
+<h3 id="1-it-provided-time-to-think">1. It provided time to think.</h3>
 <p>Career planning is not something that I personally have never really
 taken time out to sit down and think about. It's just one of those
 things that never seems a priority (though it definitely is!) If you're
@@ -184,7 +184,7 @@ path head-on, rather than putting it off for another day. We had regular
 group meetings, and had to spend time between meetings working on
 exercises, which were designed to get us thinking about career options
 and help narrow down the possible choices.</p>
-<h3>2. It provided time for the staff to understand our motivations.</h3>
+<h3 id="2-it-provided-time-for-the-staff-to-understand-our-motivations">2. It provided time for the staff to understand our motivations.</h3>
 <p>I'd previously considered consulting the university careers service. On
 reflection, I don't think this would have been too effective. It's hard
 for someone to advise you in a brief meeting without knowing you that
@@ -195,7 +195,7 @@ advice geared to what you, as an individual, want.</p>
 of weeks and months was a real benefit. They developed a great
 understanding of who we were and where we wanted to go, which helped
 them to give us personalised advice.</p>
-<h3>3. It provided us with mentors who were willing to discuss ideas and approaches.</h3>
+<h3 id="3-it-provided-us-with-mentors-who-were-willing-to-discuss-ideas-and-approaches">3. It provided us with mentors who were willing to discuss ideas and approaches.</h3>
 <p>Not only did we have the enjoyable regular meetings, but we had constant
 — and exemplary — email and phone support from the staff. Having the
 outside opinion of people who know a lot about career development is
@@ -205,7 +205,7 @@ who's going to have a well-considered opinion is a boon. Through this
 consultation, my CV was completely transformed in the space of a few
 days and several phone calls from being mediocre into something that I
 was happy to send out.</p>
-<h3>4. It provided peer support.</h3>
+<h3 id="4-it-provided-peer-support">4. It provided peer support.</h3>
 <p>Job searching is usually carried out in isolation. Because of that, it's
 easy to worry and lose perspective on your situation, especially when
 facing rejection. Knowing the similar trials that others are going
@@ -221,7 +221,7 @@ applications. Here, the continuous support, feedback and encouragement
 from peers (and staff) was a tremendous boost in keeping me motivated
 during the often frustrating task of applying for work.</p>
 <hr />
-<h2>So, what should universities be doing?</h2>
+<h2 id="so-what-should-universities-be-doing">So, what should universities be doing?</h2>
 <p>Well, as <a href="http://www.economist.com/node/17723223">many PhD and postdoctoral
 researchers are unlikely to have a permanent academic
 career</a>, universities should be
@@ -314,14 +314,14 @@ you've worked in for so long.&#160;<a class="footnote-backref" href="#fnref:1" r
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/installing-bokeh-on-ubuntu-1204-lts.html
+++ b/posts/installing-bokeh-on-ubuntu-1204-lts.html
@@ -191,14 +191,14 @@ in a few months.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/installing-matplotlib-in-virtualenv.html
+++ b/posts/installing-matplotlib-in-virtualenv.html
@@ -225,14 +225,14 @@ the minimum of required packages.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/installing-python-modules-on-windows.html
+++ b/posts/installing-python-modules-on-windows.html
@@ -184,14 +184,14 @@ compiled Python scientific packages available.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/its-not-often-that-i-think-of-technical.html
+++ b/posts/its-not-often-that-i-think-of-technical.html
@@ -205,14 +205,14 @@ enough? Who knows.&#160;<a class="footnote-backref" href="#fnref:1" rev="footnot
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/job-advertisements.html
+++ b/posts/job-advertisements.html
@@ -172,14 +172,14 @@ be able to ensure that everyone gets an equal share?"</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/leaky-phone-apps.html
+++ b/posts/leaky-phone-apps.html
@@ -196,14 +196,14 @@ to help deal with this issue.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/making-aero-theme-settings-stick-in.html
+++ b/posts/making-aero-theme-settings-stick-in.html
@@ -185,14 +185,14 @@ will actually be retained when you next log on.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/making-midi-keyboard-modulation-wheel.html
+++ b/posts/making-midi-keyboard-modulation-wheel.html
@@ -187,14 +187,14 @@ directories and save the .flp file in there.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/managing-a-bitbucket-users-permissions-when-theyve-left-your-team.html
+++ b/posts/managing-a-bitbucket-users-permissions-when-theyve-left-your-team.html
@@ -106,7 +106,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Kicking the Bitbucket</h2>
+                <h2 id="kicking-the-bitbucket">Kicking the Bitbucket</h2>
 <p>What I noticed this week is that users who'd left a Bitbucket team<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel="footnote">1</a></sup>
 that I'm currently a member of were still billed as having admin access
 to several repositories. But, this wasn't by virtue of being a team
@@ -125,7 +125,7 @@ short, admittedly — for suitable bits of the API that would let me purge
 old users without having to manually click through each repository
 didn't reveal anything. Click, click, click seemed the only way to fix
 it. And if you have a lot of repositories, that's a lot of clicking.</p>
-<h2>Stop it (and tidy up)</h2>
+<h2 id="stop-it-and-tidy-up">Stop it (and tidy up)</h2>
 <p>Looking now at this late hour, it seems that I was looking in entirely
 the wrong place previously. A much, much quicker route to cleaning up is
 to browse to your team's page and select "Manage team". From there, look
@@ -144,7 +144,7 @@ to remove <strong>all</strong> the user's permissions from your team. In just on
 click. What happens if you do that for a user that's still on the team?
 I can't answer that; maybe it boots them out of the team too? (I wasn't
 about to try it.)</p>
-<h2>A potentially money saving tip</h2>
+<h2 id="a-potentially-money-saving-tip">A potentially money saving tip</h2>
 <p>It's sensible to keep access permissions to your repositories to a
 minimum to ensure that only users who need access have it. Of course, it
 may be that you have equally sensible reasons to retain access for
@@ -208,14 +208,14 @@ might allow you to switch to a cheaper Bitbucket plan for your team too.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/migrating-email-from-pop-to-imap.html
+++ b/posts/migrating-email-from-pop-to-imap.html
@@ -228,14 +228,14 @@ Repeat for each mail folder.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/my-wifis-connected-but-theres-no.html
+++ b/posts/my-wifis-connected-but-theres-no.html
@@ -121,7 +121,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Intel Outside (of my own office)</h2>
+                <h2 id="intel-outside-of-my-own-office">Intel Outside (of my own office)</h2>
 <p>One thing I've never had too much of a problem with on my Ubuntu 12.04
 LTS install is networking. There's been the odd time when it's refused
 to connect to the network, despite everything else being fine. This has
@@ -147,7 +147,7 @@ noise relating to every wireless problem out there and not anything much
 of relevance, but I didn't have a lot more to go on. Having to do lots
 of searching and skimming through web pages using a phone to search
 isn't ideal either, but it did eventually lead me to the right answer.</p>
-<h2>Fun with <code>iwlwifi</code></h2>
+<h2 id="fun-with-iwlwifi">Fun with <code>iwlwifi</code></h2>
 <p>What worked was searching for issues relating to the wifi driver
 (<code>iwlwifi</code>). A common theme that came up was <code>11n_disable=1</code> which is a
 modprobe option that disables the wireless N feature of the Intel
@@ -170,7 +170,7 @@ disabled. (The offending module is <code>iwlwifi</code> but I couldn't <code>rmm
 until I'd removed <code>iwldvm</code> as trying to do so showed that <code>iwldvm</code> was
 using <code>iwlwifi</code>. There is a force option for <code>rmmod</code> but it didn't seem
 sensible to use it when there was an alternative.)</p>
-<h2>Making this fix stick</h2>
+<h2 id="making-this-fix-stick">Making this fix stick</h2>
 <p>If you want this fix to apply every time you boot, you can just create a
 new <code>.conf</code> file:</p>
 <p><code>/etc/modprobe.d/wireless-n-fix-iwlwifi.conf</code>, adding just this line to
@@ -184,7 +184,7 @@ summary</a>.)</p>
 <p>You can choose any valid filename you like, provided it ends in <code>.conf</code>;
 you'll also need to edit this using <code>sudo</code> and your favourite text
 editor.</p>
-<h2>Why hadn't I seen this problem before?</h2>
+<h2 id="why-hadnt-i-seen-this-problem-before">Why hadn't I seen this problem before?</h2>
 <p>What seems to be the issue is that I think that the office was using a
 wireless N router, and there's some kind of issue with this for the
 Intel Centrino wireless network adapter on my laptop under Ubuntu.</p>
@@ -234,14 +234,14 @@ yet it's still present... but at least there's a workaround.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/odd-behaviour-of-bitlocker-or-maybe-my.html
+++ b/posts/odd-behaviour-of-bitlocker-or-maybe-my.html
@@ -189,14 +189,14 @@ similar.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/patching-android-roms-for-pdroid-using.html
+++ b/posts/patching-android-roms-for-pdroid-using.html
@@ -212,14 +212,14 @@ finished!</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/phone-upgrades-and-privacy-downgrades.html
+++ b/posts/phone-upgrades-and-privacy-downgrades.html
@@ -125,7 +125,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>G300 to Moto G</h2>
+                <h2 id="g300-to-moto-g">G300 to Moto G</h2>
 <p>My G300 has been getting tired. It's a little irritating that I know
 it's inherently defective. There's a <a href="http://www.modaco.com/topic/366014-a-warning-to-all-g300-owners-please-read-hynix-flash-memory-problem/">flash memory
 issue</a>
@@ -153,7 +153,7 @@ haven't had much chance to use it yet. Initially, I was having issues
 rooting the phone with Motorola's server not recognising the phone's
 unlock data. A couple of days later all went fine, but I've only just
 got time to start setting it up again.</p>
-<h2>PDroid to XPrivacy</h2>
+<h2 id="pdroid-to-xprivacy">PDroid to XPrivacy</h2>
 <p>By setting it up, I mean the necessary business of moving existing data
 across from my old phone, as well as making sure my phone's rooted and
 running an ad-blocker and something to control app permissions for
@@ -213,14 +213,14 @@ moment, so I think I'll try and see how I get on with stock for now.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/pypi-releasing-frustration.html
+++ b/posts/pypi-releasing-frustration.html
@@ -128,7 +128,7 @@ me more like double to triple that time to complete the task.</p>
 encountered, might help save anyone else running up against the same painful
 brick walls that I did, and allow them to share their work with the Python
 community.</p>
-<h2>Starting out</h2>
+<h2 id="starting-out">Starting out</h2>
 <p>A good starting point is a
 <a href="https://packaging.python.org/en/latest/distributing/#uploading-your-project-to-pypi">guide</a>
 on the official Python site that's fairly comprehensive.</p>
@@ -142,7 +142,7 @@ if they didn't even need such warnings in the first place. (I'm also willing to
 bet there's still a non-zero number of people on affected versions of Python
 who follow instructions elsewhere without even being aware of sending their
 passwords in the clear.)</p>
-<h2>Testing times</h2>
+<h2 id="testing-times">Testing times</h2>
 <p>As the Python packaging guide mentions, there's a <a href="https://testpypi.python.org">PyPI test
 site</a> that you can use to test out uploading your
 package before you do the same on the live site.</p>
@@ -179,7 +179,7 @@ repository = https://pypi.python.org/pypi
 not want it lying around in plain text in a configuration file. If you don't
 already have accounts on the live and test PyPI sites, this point is a
 good time to create them. You won't be able to progress much further otherwise.</p>
-<h3>Building the project distribution</h3>
+<h3 id="building-the-project-distribution">Building the project distribution</h3>
 <p>Provided you've got <code>setup.py</code> configured correctly, it's not too difficult to
 build for distribution. I used the example from the <a href="https://github.com/pypa/sampleproject">PyPA sample
 project</a> as a starting point. It's also
@@ -198,7 +198,7 @@ which arguments you should use with <code>setup.py</code> to build your package.
 </pre></div>
 
 
-<h3>Registering the project</h3>
+<h3 id="registering-the-project">Registering the project</h3>
 <p>Since <code>twine</code> is recommended, it seemed sensible to use that. As my
 package is for Python 2 only — since a dependency doesn't support Python
 3 yet — it also seemed sensible to do the distribution upload using
@@ -232,7 +232,7 @@ in my password.</p>
 <p>At this stage, I gave up trying at this point and went directly to the test
 site to register the package so I could at least make some progress and feel
 slightly less incompetent. That worked without a hitch.</p>
-<h3>Adding a description</h3>
+<h3 id="adding-a-description">Adding a description</h3>
 <p>On to the next problem. Unfortunately, the PyPI site doesn't support the
 display of Markdown READMEs for package descriptions. So, before you actually
 upload a package, you should provide the package description in a form that
@@ -260,7 +260,7 @@ whether read in from a file, or included in full in the <code>setup.py</code> it
 looked the same as it did when using Markdown. I also edited the README
 slightly to use nicer looking markup for headings than the source Pandoc
 generated. </p>
-<h3>Uploading</h3>
+<h3 id="uploading">Uploading</h3>
 <p>Whew! Back to <code>twine</code>, and now the project's registered, let's try uploading it
 via:</p>
 <div class="highlight"><pre><span></span>twine upload dist/* -r testpypi
@@ -287,7 +287,7 @@ actually was.</p>
 <p>Anyway, removing these transition markers, running <code>setup.py</code> and uploading yet
 again <strong>finally</strong> enabled my README to be correctly displayed as the package
 description.</p>
-<h3>Releasing</h3>
+<h3 id="releasing">Releasing</h3>
 <p>Once that worked, all I had to do was revert the change to the version number
 I'd made in <code>setup.py</code> during testing, and then repeat the whole process on the
 real PyPI site. Having negotiated all the obstacles the first time, I was
@@ -345,14 +345,14 @@ not worth the trouble to release on PyPI.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/restoring-a-tag-cloud-dispersed-by-pelican-360.html
+++ b/posts/restoring-a-tag-cloud-dispersed-by-pelican-360.html
@@ -112,7 +112,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>The case of the disappearing tag cloud</h2>
+                <h2 id="the-case-of-the-disappearing-tag-cloud">The case of the disappearing tag cloud</h2>
 <p>As you can probably tell — if not from the posts mentioning Pelican,
 then the giveaway is the footer of each page — my site is currently
 built using <a href="https://github.com/getpelican/pelican">Pelican</a>.</p>
@@ -127,7 +127,7 @@ docs</a>
 first, I would have saved the time...) From there, it's a simple fix.
 Install the plugin, add it to your <code>PLUGINS</code> in <code>pelicanconf.py</code> and the
 tag cloud will be restored.</p>
-<h2>Installing Pelican plugins</h2>
+<h2 id="installing-pelican-plugins">Installing Pelican plugins</h2>
 <p>One small frustration is that the official plugin
 <a href="https://github.com/getpelican/pelican-plugins">repository</a> is, if maybe
 not monolithic, a substantial size. The appeal of a central repository
@@ -139,7 +139,7 @@ plugins: seventy at the time of writing. Also, when a plugin is updated
 by its author, they additionally have to put a pull request into the
 plugins repository to keep the submodule or files stored there in sync,
 which is extra work for everyone involved too.</p>
-<h2>My tag cloud plugin fork</h2>
+<h2 id="my-tag-cloud-plugin-fork">My tag cloud plugin fork</h2>
 <p>One solution for installing the plugin would be to write a simple shell
 script that does the cloning and just keeps the tag plugin. Instead, I
 felt that it would be both simpler and more sensible — rather than
@@ -203,14 +203,14 @@ that shows up in the upper right sidebar.&#160;<a class="footnote-backref" href=
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/rockbox-ipod-nano-2g-and-inverted-audio.html
+++ b/posts/rockbox-ipod-nano-2g-and-inverted-audio.html
@@ -179,14 +179,14 @@ easy fix, of course, is to just switch headphones around.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/scraping-natures-job-website.html
+++ b/posts/scraping-natures-job-website.html
@@ -180,14 +180,14 @@ Full instructions are on
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/securely-erasing-frozen-hard-disks-with-hdparm.html
+++ b/posts/securely-erasing-frozen-hard-disks-with-hdparm.html
@@ -125,7 +125,7 @@ the lengthy page where I found them below, and discuss how to deal with
 <p>You can access hdparm by booting into, for example, an Ubuntu
 installation DVD or USB. Installing Linux isn't required: you can just
 "Try Ubuntu" instead which doesn't install anything at all.</p>
-<h2>Safety first</h2>
+<h2 id="safety-first">Safety first</h2>
 <p>First, the most sensible thing to do when erasing a drive is remove any
 drives other than those you wish to erase. It means even if you
 accidentally type the wrong thing that you won't erase a drive that you
@@ -138,7 +138,7 @@ Ctrl+Alt+T.</p>
 
 <p>This will show you details of the disk, including the name. Replace the
 <code>/dev/sdX</code> in the commands below with that name.</p>
-<h2>Setting a password</h2>
+<h2 id="setting-a-password">Setting a password</h2>
 <p>The next task is to set a password. I'm not sure that you really need to
 do this, but the
 <a href="https://ata.wiki.kernel.org/index.php/ATA_Secure_Erase">kernel.org guide</a>
@@ -166,7 +166,7 @@ be a simple fix.  First, check the drive's current status via:</p>
 <p>and you may see "frozen",  as opposed to "not frozen", in the "Security"
 section of the <code>hdparm</code> output. This means you can't change security
 settings, so attempting to set a password fails.</p>
-<h2>Unfreezing</h2>
+<h2 id="unfreezing">Unfreezing</h2>
 <p>In this case, the <a href="https://superuser.com/questions/810867/new-ssd-hdparm-shows-frozen-whether-secure-erase-is-needed-before-installing">actual
 fix</a>
 is simple. Suspending the PC, then powering it back on should then give
@@ -176,7 +176,7 @@ above again.</p>
 <code>SECURITY_SET_PASS</code> command without error. Also, rerunning the <code>hdparm
 -I</code> command yet another time should show that a password is "enabled" as
 opposed to "not enabled".</p>
-<h2>Erasing</h2>
+<h2 id="erasing">Erasing</h2>
 <p>You can now proceed with the erase. If your drive's <code>hdparm</code> output
 states <code>supported: enhanced erase</code>, you could replace the
 <code>--security-erase</code> below with <code>--security-erase-enhanced</code>:</p>
@@ -228,14 +228,14 @@ enabled".</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/securely-erasing-ssd-drives.html
+++ b/posts/securely-erasing-ssd-drives.html
@@ -197,14 +197,14 @@ using shred or dd.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/some-spring-winter-ubuntu-cleaning.html
+++ b/posts/some-spring-winter-ubuntu-cleaning.html
@@ -253,14 +253,14 @@ this</a> while writing.&#160;<a class="footnote-backref" href="#fnref:2" rev="fo
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/still-rocking-rockbox.html
+++ b/posts/still-rocking-rockbox.html
@@ -127,7 +127,7 @@ source replacement firmware for audio players. Since then, Rockbox has
 become one of the open source projects that I use most. I've used it
 near daily on some device or other for probably around a decade, and I
 don't see that changing anytime soon.</p>
-<h2>Easy listening</h2>
+<h2 id="easy-listening">Easy listening</h2>
 <p>As an audio player is one of the things I'm using all the time, I like
 having a separate device with its own, usually lengthy, battery life.
 With that in mind, I'm probably a little ignorant if there's phone audio
@@ -142,7 +142,7 @@ is fully customisable should you wish to create your own.  Furthermore,
 if a device has the option of adding external media card storage, such
 as microSD, Rockbox sometimes goes beyond a device's official support,
 enabling the use of larger memory cards.</p>
-<h2>Installing Rockbox</h2>
+<h2 id="installing-rockbox">Installing Rockbox</h2>
 <p>If you want to give it a try, the first step is to take a look at the
 <a href="https://rockbox.org">official site</a> and see what devices are currently
 supported. It's also worth checking around the forums there too,
@@ -177,7 +177,7 @@ find-replace tool to patch the source to replace URLs that match, for
 example (but not limited to) http://download.rockbox.org to use HTTPS. I
 really should have submitted a patch but I couldn't face the hassle of
 creating a account to access Rockbox's Gerrit instance at the time.</p>
-<h2>The future?</h2>
+<h2 id="the-future">The future?</h2>
 <p>What's the long, long term future of the project? If you've hardware for
 which Rockbox is claimed to be stable, you'll probably find that's the
 case. I've had devices occasionally lock up, but these haven't happened
@@ -244,14 +244,14 @@ using it over the next ten years as I have for the last ten.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/stopping-windows-from-rebooting-at-the-bitlocker-boot-password-prompt.html
+++ b/posts/stopping-windows-from-rebooting-at-the-bitlocker-boot-password-prompt.html
@@ -166,14 +166,14 @@ indefinitely.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/taking-control-of-chromium-and-chrome.html
+++ b/posts/taking-control-of-chromium-and-chrome.html
@@ -158,7 +158,7 @@ currently is.</p>
 <p>In fact, the adblocking part of HTTP Switchboard has now been separated
 out into another project, ublock. Both are still useful. I'll explain
 why below.</p>
-<h2>Why are you blocking content at all?</h2>
+<h2 id="why-are-you-blocking-content-at-all">Why are you blocking content at all?</h2>
 <p>Many content-driven websites use advertising as their business model. My
 feeling is that, while sites are welcome to try and send content to my
 browser, I should have the freedom to choose what my browser actually
@@ -171,7 +171,7 @@ model sustainable.</p>
 But, my privacy and computer security are more important to me than the
 financial success or failure of an external organisation. That I put my
 priorities in this order is kind of obvious though, right?</p>
-<h2>Why shouldn't sites and advertisers worry so much?</h2>
+<h2 id="why-shouldnt-sites-and-advertisers-worry-so-much">Why shouldn't sites and advertisers worry so much?</h2>
 <p>Even with "despicable" users like me, there are two reasons I can think
 of as to why advertisers and sites dependent on them shouldn't feel so
 glum:</p>
@@ -188,8 +188,8 @@ glum:</p>
     browsers just for adblocking?</p>
 </li>
 </ol>
-<h2>But why worry about where displayed web content originates from?</h2>
-<h3>Privacy</h3>
+<h2 id="but-why-worry-about-where-displayed-web-content-originates-from">But why worry about where displayed web content originates from?</h2>
+<h3 id="privacy">Privacy</h3>
 <p>One contentious issue with ads and cookies is privacy.</p>
 <p>As <a href="http://www.economist.com/news/special-report/21615871-everything-people-do-online-avidly-followed-advertisers-and-third-party">this Economist
 article</a>
@@ -207,7 +207,7 @@ out if you are a high-value customer and are in the market for a car."</p>
 <p>But, the sheer amount of information being collected is worrying,
 especially when, as a user, I've no idea of what's actually being
 tracked and what the intended end use is.</p>
-<h3>Malware</h3>
+<h3 id="malware">Malware</h3>
 <p>As well as that, web advertising has been a conduit for the deployment
 of malware previously and will no doubt continue to be. (It's a nice way
 of distributing it to users who are visiting, what to them, might seem
@@ -234,7 +234,7 @@ is here; often JQuery's needed for sites to function as intended...)</p>
 load from can't be a bad thing. (There's some risk wherever you go, but
 in some cases, I've seen sites loading in content from more sites than I
 can count on both hands.)</p>
-<h2>Controlling what your browser displays</h2>
+<h2 id="controlling-what-your-browser-displays">Controlling what your browser displays</h2>
 <p>So, what can you do? There are browser extensions for Firefox and Chrome
 that give you more control over what your browser loads.</p>
 <p>Lots of sites are perfectly readable without them storing tracking
@@ -255,7 +255,7 @@ extensions, NoScript, RequestPolicy. Recently, the <a href="https://github.com/g
 pattern-based filtering</a>
 has been split out into another project,
 <a href="https://github.com/gorhill/ublock">ublock</a>.</p>
-<h2>ublock</h2>
+<h2 id="ublock">ublock</h2>
 <p>By virtue of what HTTP Switchboard aims to do — give you full control of
 what is allowed by your browser — this makes its user interface slightly
 more complex, which I'll soon get onto.</p>
@@ -273,7 +273,7 @@ usage. If you've ditched an ad blocker for this reason, it's worth
 looking at. Even if you're still happy using Adblock Plus (or one of its
 forks), ublock is definitely worth spending the couple of minutes to try
 it out.</p>
-<h2>HTTP Switchboard</h2>
+<h2 id="http-switchboard">HTTP Switchboard</h2>
 <p>On to HTTP Switchboard, which allows fine grained control of the types
 and locations of content that Chromium-based browser can access.</p>
 <p>Note that with the current version of HTTP Switchboard, there's a little
@@ -341,7 +341,7 @@ database of sites telling you "hey, you might need this, it's a content
 delivery network" or "this is tracking how you're using the site; you
 probably don't need it for the site to function properly". Yes, I can
 search, but it's a bit clunky to do that.</p>
-<h2>A summary</h2>
+<h2 id="a-summary">A summary</h2>
 <p>These are really great browser extensions, and credit to Raymond Hill
 for an awesome job on them. Every time I'm managing permissions with
 multiple extensions in Firefox now, I sigh a little. (Firefox's awesome
@@ -395,14 +395,14 @@ HTTPS Everywhere enables it for you.)</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/taking-web-page-screenshots-smartly-with-firefoxs-developer-tools.html
+++ b/posts/taking-web-page-screenshots-smartly-with-firefoxs-developer-tools.html
@@ -109,7 +109,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>Snap happy</h2>
+                <h2 id="snap-happy">Snap happy</h2>
 <p>Firefox has a buried feature in its Developer Tools, which is potentially
 useful even if you're not a developer. If you've never used the Developer
 Tools, just press F12 and you'll see the tools.</p>
@@ -124,7 +124,7 @@ Downloads.</p>
 <p>This is a really handy feature. It means that you can take an image of a
 scrollable page that's <strong>larger</strong> than your current window. No need for
 screenshotting parts of the page then joining them together by hand.</p>
-<h2>Solving bigger problems</h2>
+<h2 id="solving-bigger-problems">Solving bigger problems</h2>
 <p>But what if you want to enlarge the visible area beyond the size of your
 current window, and then take a screenshot?</p>
 <p>Why would this be even useful?</p>
@@ -188,14 +188,14 @@ you've selected.)</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/the-case-of-a-windows-7-update-secure-boot-and-a-suspect-motherboard.html
+++ b/posts/the-case-of-a-windows-7-update-secure-boot-and-a-suspect-motherboard.html
@@ -117,7 +117,7 @@ stevenmaude.co.uk            </a>
 Boot works on a Monday evening, I'm writing this up. </p>
 <p>Maybe you're experiencing this problem right now. Maybe you're not, but you're
 intrigued as to how I go about diagnosing computer problems.</p>
-<h2>A stubborn PC</h2>
+<h2 id="a-stubborn-pc">A stubborn PC</h2>
 <p>I maintain a PC that has Windows 7 installed (due to be upgraded to Windows 10)
 and, yesterday evening, installed several optional updates.<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel="footnote">1</a></sup> Nothing unusual
 there.</p>
@@ -142,7 +142,7 @@ seemed fairly routine, except <a href="https://support.microsoft.com/en-gb/kb/31
 issue</a>. What stood out were the
 changes to Windows Boot Manager files <code>Bootmgr.efi</code> and <code>Bootmgfw.efi</code>, which
 also suggested the update was at fault.</p>
-<h2>ASUSpect?</h2>
+<h2 id="asuspect">ASUSpect?</h2>
 <p>Searching around led me to several recent links, as I mentioned in comments on
 this <a href="https://superuser.com/questions/1054790/system-found-unauthorized-changes-on-the-firmware">SuperUser
 question</a>.</p>
@@ -183,7 +183,7 @@ fix is one of those already suggested here: disable Secure Boot.</p>
 <p>(It's a while ago since I installed the PC, but I guess that I originally must
 have tried turning on Secure Boot during installation and, since the PC booted
 without a problem, left it enabled.)</p>
-<h2>What to do?</h2>
+<h2 id="what-to-do">What to do?</h2>
 <p>Other posts I'd read indicated that removing KB3133977 didn't solve this.
 Perhaps there are EFI changes that don't get reverted when you uninstall the
 update? Who knows?</p>
@@ -212,7 +212,7 @@ fixing this was correct. I deleted the keys on my ASUS Sabertooth
 z97 motherboard and was able to boot.</p>
 </blockquote>
 </div>
-<h2>One more thing</h2>
+<h2 id="one-more-thing">One more thing</h2>
 <p>Incidentally, I wondered what happens if you disable Secure Boot, then do an
 in-place upgrade of Windows in this situation, where we can't enable Secure
 Boot? Can you later enable it?</p>
@@ -282,14 +282,14 @@ Windows 10</a>.&#160;<a class="footnote-backref" href="#fnref:1" rev="footnote" 
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/the-death-of-desktop-pc.html
+++ b/posts/the-death-of-desktop-pc.html
@@ -133,7 +133,7 @@ first laptop for work, and <strong>still</strong> haven't been converted to mobi
 devices.</p>
 <p>So, why such distinct differences between the needs of mainstream users
 and enthusiasts? Here's what my experiences tell me.</p>
-<h2>Upgradability</h2>
+<h2 id="upgradability">Upgradability</h2>
 <p>First off, even before you purchase a laptop you run into problems if
 you're particularly interested in the computer you end up with. There
 are a huge number of different machines out there. However, laptops have
@@ -153,7 +153,7 @@ or two.</p>
 would be relatively simple in a desktop (take out broken part, install
 new part) may well involve sending your laptop to the manufacturer or
 repair shop, rather frustratingly.</p>
-<h2>Usability</h2>
+<h2 id="usability">Usability</h2>
 <p>Laptops come with built-in keyboards and trackpads which I find awkward.
 I almost always use other input devices with my laptop. Trackpads are
 just too imprecise and inefficient compared with mice, while laptop
@@ -169,7 +169,7 @@ I much prefer working on larger (> 22 inch) monitors, and I always
 favour plugging my laptop into an external monitor. Having to work
 around the limitations of a low resolution screen by constantly
 scrolling or shuffling windows around is distracting.</p>
-<h2>Power</h2>
+<h2 id="power">Power</h2>
 <p>Laptops are portable machines which has two consequences. Obviously,
 they need to be small, which means there's no room for the several fans
 and large heatsinks that desktop cases can accommodate. They also need
@@ -182,7 +182,7 @@ played have been indie titles with modest requirements (my almost seven
 year old desktop still handles these well). However, there's a large
 community of PC gamers who won't be satisfied by the compromises in
 performance they'd have to make on choosing a laptop.</p>
-<h2>Phones and tablets versus conventional PCs</h2>
+<h2 id="phones-and-tablets-versus-conventional-pcs">Phones and tablets versus conventional PCs</h2>
 <p>Since they can run the same software, I've focused on desktops versus
 laptops as these devices are, in principle at least, interchangeable,
 and I've not mentioned phones and tablets. Apart from their portability,
@@ -251,14 +251,14 @@ is still an important one for computer enthusiasts.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/things-ive-learned-from-building-and.html
+++ b/posts/things-ive-learned-from-building-and.html
@@ -162,7 +162,7 @@ with the motherboard<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel="
 technical support, it didn't improve things. I'd wasted that much time
 on it, I just gave up and just ordered another board instead, and
 (fingers crossed) everything seems OK at the minute.</p>
-<h2>So, some things I learned:</h2>
+<h2 id="so-some-things-i-learned">So, some things I learned:</h2>
 <p>1. Unless you constantly keep track of what's going on in the world of
 PC components, <strong>the choice of PC components is a little overwhelming</strong>.
 For me, getting several use out of a PC isn't unreasonable with some
@@ -283,14 +283,14 @@ just built this PC, it's quite tempting to build one for myself...&#160;<a class
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/thinking-of-using-a-static-site-generator-for-your-blog.html
+++ b/posts/thinking-of-using-a-static-site-generator-for-your-blog.html
@@ -132,8 +132,8 @@ you might deal with in shifting.</p>
 <p>While I'm familiar with Pelican and Blogger, most of the points apply
 generally so could still be informative for you if you're considering a
 move from, say, Wordpress to Jekyll.</p>
-<h2>Converting and writing content (Markdown)</h2>
-<h3>Bad</h3>
+<h2 id="converting-and-writing-content-markdown">Converting and writing content (Markdown)</h2>
+<h3 id="bad">Bad</h3>
 <ul>
 <li>
 <p>Depending on what you used to create a blog previously, and how much
@@ -161,7 +161,7 @@ compromise that's at least compatible with different Markdown
 implementations.</p>
 </li>
 </ul>
-<h3>Good</h3>
+<h3 id="good">Good</h3>
 <ul>
 <li>All my content is in fairly plain Markdown which I love writing in.
     It also means that I'm far less locked into Pelican than I was ever
@@ -169,8 +169,8 @@ implementations.</p>
     generator, only the metadata and Python-Markdown specific tweaks may
     need adjusting.</li>
 </ul>
-<h2>Adding content to the site and hosting</h2>
-<h3>Bad</h3>
+<h2 id="adding-content-to-the-site-and-hosting">Adding content to the site and hosting</h2>
+<h3 id="bad_1">Bad</h3>
 <ul>
 <li>My git repositories are structured in a way that I like: blog HTML,
     the theme I use, my Pelican configuration, my Markdown posts, and
@@ -181,7 +181,7 @@ implementations.</p>
     usually do this via branches too, which is more work too (though
     this is my choice). Improving this workflow is on my to-do list.</li>
 </ul>
-<h3>Good</h3>
+<h3 id="good_1">Good</h3>
 <ul>
 <li>
 <p>My blog's not trapped within Google's servers. Certainly, I'm wary
@@ -221,14 +221,14 @@ implementations.</p>
     own domain is free, but it's likely you'll need to pay for hosting.</p>
 </li>
 </ul>
-<h2>Appearance and viewer experience</h2>
-<h3>Bad</h3>
+<h2 id="appearance-and-viewer-experience">Appearance and viewer experience</h2>
+<h3 id="bad_2">Bad</h3>
 <ul>
 <li>With Pelican (probably much less so for Jekyll), there's not a huge
     range of themes. If you're fussy like me, you may need to spend some
     time tweaking, or creating your own. </li>
 </ul>
-<h3>Good</h3>
+<h3 id="good_2">Good</h3>
 <ul>
 <li>
 <p>My site now functions without the viewer needing JavaScript. With
@@ -248,8 +248,8 @@ implementations.</p>
     you'd need a JavaScript plugin for syntax highlighting.</p>
 </li>
 </ul>
-<h2>Running the generator</h2>
-<h3>Bad</h3>
+<h2 id="running-the-generator">Running the generator</h2>
+<h3 id="bad_3">Bad</h3>
 <ul>
 <li>
 <p>Static site generators are not for the impatient. For Pelican, being
@@ -268,7 +268,7 @@ implementations.</p>
     rebuilt when running the development server.</p>
 </li>
 </ul>
-<h3>Good</h3>
+<h3 id="good_3">Good</h3>
 <ul>
 <li>
 <p>Pelican is nice to use, and I had very few problems in doing so.
@@ -287,7 +287,7 @@ implementations.</p>
     applies to Wordpress' source too incidentally.)</p>
 </li>
 </ul>
-<h2>Living with a static site</h2>
+<h2 id="living-with-a-static-site">Living with a static site</h2>
 <p>When worrying about the limitations that static sites may have, think
 about the actual minimum you need on a web site to share and present
 written ideas and thoughts you have. It's really not very much; do you
@@ -351,14 +351,14 @@ that Blogger ever did for my inspiration.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/types-of-data-scientist.html
+++ b/posts/types-of-data-scientist.html
@@ -231,14 +231,14 @@ ago</a> that
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/uninstalling-gotomeeting.html
+++ b/posts/uninstalling-gotomeeting.html
@@ -180,14 +180,14 @@ hadn't done a thing.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/updating-and-rooting-moto-g.html
+++ b/posts/updating-and-rooting-moto-g.html
@@ -125,7 +125,7 @@ stevenmaude.co.uk            </a>
     
 </footer><!-- /.post-info -->                    </div>
                 </div>
-                <h2>My Moto G has been nagging me to upgrade firmware</h2>
+                <h2 id="my-moto-g-has-been-nagging-me-to-upgrade-firmware">My Moto G has been nagging me to upgrade firmware</h2>
 <p>So I did today.</p>
 <p>(I was persuaded by the Motorola system updater. Not because it's a
 lovely looking bit of software, but because it makes nagging an art with
@@ -161,7 +161,7 @@ but if it was something like the developer options where you have to
 deliberately enable it, then they wouldn't even know it was present.</p>
 <p>Anyway, here are the reference notes I made while upgrading for (the
 inevitable) next time.</p>
-<h2>Preliminary setup with Ubuntu</h2>
+<h2 id="preliminary-setup-with-ubuntu">Preliminary setup with Ubuntu</h2>
 <p>(or your choice of a Linux that has <code>adb</code> and <code>fastboot</code>)</p>
 <ol>
 <li>Install (to a live USB, or use an existing install on your laptop)</li>
@@ -169,12 +169,12 @@ inevitable) next time.</p>
 <li>Do <code>sudo apt-get update</code>.</li>
 <li><code>sudo apt-get install android-tools-adb android-tools-fastboot</code></li>
 </ol>
-<h2>Backup data from phone</h2>
+<h2 id="backup-data-from-phone">Backup data from phone</h2>
 <p>Copy off any photos, documents or other files you want to save.</p>
 <p>If you want to backup your call logs and text messages, Call Logs Backup
 and Restore, and SMS Backup and Restore work pretty well for me. That
 said, they do request internet permissions which I block.</p>
-<h2>Restore stock firmware</h2>
+<h2 id="restore-stock-firmware">Restore stock firmware</h2>
 <p>Stock firmwares are available
 <a href="http://sbf.droid-developers.org/phone.php?device=14">here</a> and <a href="http://forum.xda-developers.com/showthread.php?t=2542219">this
 post</a> was a
@@ -202,7 +202,7 @@ sudo fastboot reboot
 
 <p>(sparsechunk files may have numbers 0, 1, 2 - just flash them in
 ascending order.)</p>
-<h2>Upgrade</h2>
+<h2 id="upgrade">Upgrade</h2>
 <p>Boot into stock and install update.</p>
 <p><strong>To avoid heartache</strong>, make sure you check for system updates
 <strong>after</strong> you update, and install any further updates before
@@ -211,7 +211,7 @@ discover after rooting again that there are still updates remaining
 after the first one. In that case, you'll have to restore to stock again
 :( (I was on 4.4.2, but there was a minor update that didn't change the
 version before the latest 4.4.4 update.)</p>
-<h2>Unlock bootloader</h2>
+<h2 id="unlock-bootloader">Unlock bootloader</h2>
 <p><strong> Only needed if not previously unlocked; while restoring stock
 firmware and upgrading, this didn't get relocked. </strong></p>
 <p>You need a bootloader unlock code from Motorola's
@@ -234,7 +234,7 @@ firmware and upgrading, this didn't get relocked. </strong></p>
 <p>See <a href="http://wiki.cyanogenmod.org/w/Template:Unlock_Bootloader">CyanogenMod's
 site</a> for more
 details.</p>
-<h2>Install custom recovery</h2>
+<h2 id="install-custom-recovery">Install custom recovery</h2>
 <p>Get custom recovery; <a href="http://teamw.in/project/twrp2/233">I used TWRP</a>.</p>
 <p>Get a recent fastboot .img; at the time of writing, 2.7.1.1 was the
 latest, but didn't work. 2.7.1.0 worked fine.</p>
@@ -243,17 +243,17 @@ latest, but didn't work. 2.7.1.0 worked fine.</p>
 </pre></div>
 
 
-<h2>Root the phone by installing SuperSU</h2>
+<h2 id="root-the-phone-by-installing-supersu">Root the phone by installing SuperSU</h2>
 <p>Boot from bootloader into TWRP recovery. Reboot system, say yes to
 install SuperSU.</p>
 <p>Boot up, run SuperSU installer; go to Play Store and choose <strong>update</strong>
 (<strong>not</strong> open).</p>
 <p>This will probably prompt to install a new binary; the normal install
 should work fine.</p>
-<h2>Install XPrivacy</h2>
+<h2 id="install-xprivacy">Install XPrivacy</h2>
 <p>Install XPrivacy installer. Follow each of the several instruction steps
 that are shown when you run it.</p>
-<h2>Encrypt and change password again</h2>
+<h2 id="encrypt-and-change-password-again">Encrypt and change password again</h2>
 <p>Create a screen lock PIN or password, then fully charge battery and
 encrypt.</p>
 <p>Change the password using <a href="https://play.google.com/store/apps/details?id=org.nick.cryptfs.passwdmanager&amp;hl=en">Cryptfs
@@ -267,14 +267,14 @@ want to have either:</p>
 <li>a huge password that you have to enter every time you unlock your phone</li>
 </ul>
 <p>you'll need to change it using CryptFS which requires root access.)</p>
-<h2>Disable all the slow animations</h2>
+<h2 id="disable-all-the-slow-animations">Disable all the slow animations</h2>
 <p>To make Android snappier, disable the animations by enabling the
 developer options. Go in Settings > About phone, scroll to the bottom
 and keep pressing build number until it tells you the developer options
 are active. Now, in Settings > Developer options, you can set "Window
 animation scale", "Transition animation scale" and "Animator duration
 scale" all to off.</p>
-<h2>Restore data, account, messages, call logs</h2>
+<h2 id="restore-data-account-messages-call-logs">Restore data, account, messages, call logs</h2>
 <p>Reinstall SMS Backup and Restore, Call Log Backup and Restore, and
 restore the backups you made. Reinstall any other apps you want,
 including <a href="https://f-droid.org/">F-Droid</a> if you want AdAway and that's
@@ -320,14 +320,14 @@ everything finally done. No more nagging for updates!</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/us-pycon-2014-talks.html
+++ b/posts/us-pycon-2014-talks.html
@@ -134,7 +134,7 @@ selection of videos of the talks up at
 <a href="http://pyvideo.org/category/50/pycon-us-2014">pyvideo.org</a>. Still
 haven't got through all of the ones I want to take a look at, but the
 ones I've checked already were pretty good.</p>
-<h2>Regular expressions and testing</h2>
+<h2 id="regular-expressions-and-testing">Regular expressions and testing</h2>
 <p>Out of those I saw, I can definitely recommend two great mini tutorial
 talks; one on testing and one on regular expressions. What I loved about
 both is that they started from pretty much zero knowledge and built up
@@ -174,7 +174,7 @@ the result (e.g. if a web page changes).</p>
 <p>Again, I'd seen, and have used, several of these ideas before, but to
 see them all presented in one place, and explained so well, makes it a
 good resource.</p>
-<h2>Scraping</h2>
+<h2 id="scraping">Scraping</h2>
 <p>Since I do a bit of web scraping, I also skimmed a couple of
 presentations given by Katharine Jarmul. <a href="https://www.youtube.com/watch?v=p1iX0uxM1w8">Her
 tutorial</a> looked pretty
@@ -242,14 +242,14 @@ let me know! There's way too many to practically sit through.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/uses-for-a-raspberry-pi-part-1.html
+++ b/posts/uses-for-a-raspberry-pi-part-1.html
@@ -171,7 +171,7 @@ could attach a keyboard and TV/monitor to it and enter terminal commands
 directly.</p>
 <p>So, what can you use a Pi for?</p>
 <hr />
-<h2>1. Access to useful Linux command line tools</h2>
+<h2 id="1-access-to-useful-linux-command-line-tools">1. Access to useful Linux command line tools</h2>
 <p>Even just installing a Linux distribution like Raspbian, <em>without
 installing anything else</em>, gives you access to <a href="https://en.wikipedia.org/wiki/List_of_Unix_utilities">several powerful
 programs</a>
@@ -191,7 +191,7 @@ the <a href="http://git-scm.com/">git</a> command line tool from the Pi. <em>It 
 worked.</em> In my case, git had already been installed, so I didn't even
 need to type <code>sudo apt-get install git</code>. This was a lot
 simpler than me trying to decide on the best way to run git on Windows.</p>
-<h2>2. Wireless adapter for a device without onboard wifi</h2>
+<h2 id="2-wireless-adapter-for-a-device-without-onboard-wifi">2. Wireless adapter for a device without onboard wifi</h2>
 <p>I installed a cheap Ralink wifi adapter (around £4 from eBay) to connect
 my Pi to a wireless network. Because of this, the Pi's onboard Ethernet
 port was going unused. It's relatively straightforward to configure the
@@ -204,7 +204,7 @@ Stack Exchange post</a> how to
 configure the Pi such that the Xbox can access the network. There's no
 reason why the same procedure couldn't be used for other networked
 devices without wifi.</p>
-<h2>3. AirPrint server</h2>
+<h2 id="3-airprint-server">3. AirPrint server</h2>
 <p>Earlier this year, I was asked, "How can I print something from my
 iPad?"
 My reply was along the lines of, "Not easily: we don't have a printer
@@ -281,14 +281,14 @@ to be a great alternative to the BBC's officially supported service.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/uses-for-a-raspberry-pi-part-2.html
+++ b/posts/uses-for-a-raspberry-pi-part-2.html
@@ -140,7 +140,7 @@ post</a>,
 I described a few simple, but effective uses for a Raspberry Pi. Here
 are two more!</p>
 <hr />
-<h2>4. File server using Samba, and media server using MiniDLNA</h2>
+<h2 id="4-file-server-using-samba-and-media-server-using-minidlna">4. File server using Samba, and media server using MiniDLNA</h2>
 <p>The Pi makes for a useful low cost file server. I used <a href="http://elinux.org/R-Pi_NAS">this
 guide</a> to install Samba which enables file
 shares to be accessed via Windows (and also OS X). It's pretty easy to
@@ -152,8 +152,8 @@ solution.</p>
 MiniDLNA</a> to
 allow networked media devices to easily access video and audio on the
 Pi, though I've not tested this personally.</p>
-<h2>5. <code>get_iplayer</code>: for UK users (or overseas users with e.g. VPN access)</h2>
-<h3>What's <code>get_iplayer</code>?</h3>
+<h2 id="5-get_iplayer-for-uk-users-or-overseas-users-with-eg-vpn-access">5. <code>get_iplayer</code>: for UK users (or overseas users with e.g. VPN access)</h2>
+<h3 id="whats-get_iplayer">What's <code>get_iplayer</code>?</h3>
 <p>For the benefit of those not in the UK,
 <a href="https://en.wikipedia.org/wiki/BBC_iPlayer">iPlayer</a> is a
 <a href="http://www.bbc.co.uk/">BBC</a> service that allows users to stream
@@ -171,7 +171,7 @@ feature: you can queue up future programmes that are already in the
 BBC's current schedule, and you can easily setup PVR searches (e.g. to
 look for a specific programme title) that can be configured to run
 periodically and download on any suitable matches.</p>
-<h3>Installation of <code>get_iplayer</code></h3>
+<h3 id="installation-of-get_iplayer">Installation of <code>get_iplayer</code></h3>
 <p>I installed <code>get_iplayer</code> last year on my Pi running Rapsbian; I followed
 <a href="http://raspi.tv/2012/get_iplayer-installation-on-raspberry-pi-with-raspbian">this
 guide</a>.
@@ -204,7 +204,7 @@ available</a></li>
 <li><code>--nopurge</code> prevents the deletion of programmes that were
 recorded more than 30 days ago.</li>
 </ul>
-<h3>Basic use</h3>
+<h3 id="basic-use">Basic use</h3>
 <p>There are <a href="https://github.com/dinkypumpkin/get_iplayer/wiki/documentation">plenty of usage
 examples</a>
 in the documentation which is definitely worth a read and explains all
@@ -239,7 +239,7 @@ programme number instead of a title:</p>
 </pre></div>
 
 
-<h3>Adding searches to the PVR</h3>
+<h3 id="adding-searches-to-the-pvr">Adding searches to the PVR</h3>
 <p>Adding searches to the PVR is very similar to downloading available
 shows. As the documentation shows, instead of the <code>--get</code>
 option, you use <code>--pvr-add</code>:</p>
@@ -267,7 +267,7 @@ interface</a>, if
 you prefer that to using the command line to manage the PVR, although
 it's advised to have it running on trusted networks for security
 reasons.</p>
-<h3>Scheduling the PVR to run</h3>
+<h3 id="scheduling-the-pvr-to-run">Scheduling the PVR to run</h3>
 <p><img class="article-image" src="http://www.stevenmaude.co.uk/images/2013/get_iplayer_crontab.png" alt="Crontab with get_iplayer scheduled."></p>
 <p>However, it is more convenient to run the PVR regularly rather than have
 to run it manually. You can add the command to run the PVR to the <a href="https://en.wikipedia.org/wiki/Cron">cron
@@ -284,19 +284,19 @@ when running via cron. This was fixed by finding the contents of my
 current PATH variable (by typing <code>echo $PATH</code> into the
 terminal) and then copying this into a line in my crontab that started
 <code>PATH=</code>.</p>
-<h3>Why I think the PVR is great</h3>
+<h3 id="why-i-think-the-pvr-is-great">Why I think the PVR is great</h3>
 <p>What's awesome about the PVR function is that <em>the search terms are
 persistent</em>. If the PVR is looking out for a particular show, you don't
 even need to keep an eye out for when your favourite shows start a new
 series, in case you forget to record it. The PVR feature will
 automatically catch them for you, without you thinking about it.</p>
-<h3>Custom commands after downloading recordings</h3>
+<h3 id="custom-commands-after-downloading-recordings">Custom commands after downloading recordings</h3>
 <p>This is another useful feature of <code>get_iplayer</code>. <code>--command</code>
 runs custom commands after downloading a recording and can pass various
 bits of information to those commands as arguments. Because of this
 feature, it's easy to <em>use your own scripts to process your
 recordings</em>.</p>
-<h3>Example: automatic downloading of radio tracklistings</h3>
+<h3 id="example-automatic-downloading-of-radio-tracklistings">Example: automatic downloading of radio tracklistings</h3>
 <p>Sometimes I'll hear a track that a DJ plays on a radio show and I'll
 want to make a note of it to look it up later. It's not always that easy
 to do, occasionally they neglect to mention the title and artist, which
@@ -330,7 +330,7 @@ file the same base filename). These are provided by <code>get_iplayer</code> via
 <p>Once this has been setup in a radio PVR search, you can forget about the
 script entirely. It should execute automatically everytime a show has
 been downloaded.</p>
-<h3>Conclusion</h3>
+<h3 id="conclusion">Conclusion</h3>
 <p><code>get_iplayer</code> does its job superbly well. It has many useful features and
 seems very stable. Comparing <code>get_iplayer</code> to the TV tuner my main PC has
 installed, <code>get_iplayer</code> has been used much more for "recording".</p>
@@ -406,14 +406,14 @@ upgrade</code>; my install is currently manually updated by running
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/using-garmin-forerunner-watches-with-linux.html
+++ b/posts/using-garmin-forerunner-watches-with-linux.html
@@ -141,7 +141,7 @@ watches, I couldn't find a huge amount of information on using them with
 Linux. This post concerns the Forerunner 15 (FR15) particularly, but
 think may well apply to several others in that range that function as
 USB storage devices, with the usual "your mileage may vary" caveats.</p>
-<h2>Can you use it with Linux?</h2>
+<h2 id="can-you-use-it-with-linux">Can you use it with Linux?</h2>
 <p>Yes, to some extent. Though you won't be able to use all the fancy
 display features on Garmin's site. That said, I'm not bothered about
 that and would actually prefer to keep my data offline, especially with
@@ -154,7 +154,7 @@ unofficial Garmin Communication web browser plugin that was capable of
 uploading data to Garmin's servers.  This no longer functions and <a href="https://github.com/adiesner/GarminPlugin/issues/14">this
 GitHub issue</a>
 suggests it won't be fixed anytime soon.</p>
-<h3>Installing GPSBabel</h3>
+<h3 id="installing-gpsbabel">Installing GPSBabel</h3>
 <p>The next job is to get the FIT files into a format that's more widely
 usable.</p>
 <p><a href="https://www.gpsbabel.org/">GPSBabel</a> is a application for Windows, OS X
@@ -192,7 +192,7 @@ was to do the following:</p>
 <p>which was probably overkill as it installed a lot of packages, but
 compiling then worked. (I then removed <code>qtcreator</code> via <code>apt-get
 remove</code>.)</p>
-<h3>Converting Garmin's FIT data to GPX</h3>
+<h3 id="converting-garmins-fit-data-to-gpx">Converting Garmin's FIT data to GPX</h3>
 <p>An example use of GPSBabel is:</p>
 <div class="highlight"><pre><span></span>gpsbabel -i garmin_fit -f input.FIT -o gpx -F output.gpx
 </pre></div>
@@ -209,7 +209,7 @@ myself.</p>
 <p>(Some of the high-end watches also have the ability to send the data to
 Garmin via Bluetooth to mobile apps that collect the data, so that's
 another way you could avoid the requirement for Windows or OS X.)</p>
-<h3>Upgrading the watch's firmware</h3>
+<h3 id="upgrading-the-watchs-firmware">Upgrading the watch's firmware</h3>
 <p>My watch came with the latest firmware installed and the watch has been
 out a while, so I doubt there are any major issues remaining. But, there
 may still be further updates as it's still a supported product.</p>
@@ -238,7 +238,7 @@ e.g. the watch firmware itself, as well as language files and the ANT
 firmware. And apparently <em>all</em> these need the header removing. Anyway,
 you can search Garmin's site for e.g. "Forerunner 15 update" and see
 what you find.</p>
-<h2>What's the watch actually like?</h2>
+<h2 id="whats-the-watch-actually-like">What's the watch actually like?</h2>
 <p>I've only started using it today, but it seems good at what it does. I
 tracked a run and, at a glance, the data looked consistent with where
 I'd been and how I'd run.</p>
@@ -323,14 +323,14 @@ user-replaceable. That drawback aside, it seems a decent choice.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/what-happens-when-github-decides-youre-not-a-human.html
+++ b/posts/what-happens-when-github-decides-youre-not-a-human.html
@@ -127,13 +127,13 @@ won't require DNA proof of your humanity.</p>
 automated systems, one short email later, it was politely resolved in
 ten minutes by GitHub's support team, who decided I was human after
 all.<sup id="fnref:1"><a class="footnote-ref" href="#fn:1" rel="footnote">1</a></sup></p>
-<h2>What might have caused it?</h2>
+<h2 id="what-might-have-caused-it">What might have caused it?</h2>
 <p>Perhaps creating several similar looking repositories (albeit with different
 code) in a relatively short space of time. These contain example code to access
 <a href="https://github.com/pdftables">the API</a> that we offer at work. Maybe it's
 because the commits looked similar, maybe because the commit messages or the
 commit content contained a URL. Who can say?</p>
-<h2>Why is this not ideal?</h2>
+<h2 id="why-is-this-not-ideal">Why is this not ideal?</h2>
 <p>Despite the quick resolution, the way this situation is handled might be
 flawed.</p>
 <p>First, though the warning was omnipresent, large and red, it didn't describe
@@ -156,7 +156,7 @@ considers you a bot. There's no grace period where you can confirm your
 identity, before they hide your profile publically. It just gets hidden
 and, what I suspect happens is, the first you know of it is when it has
 been hidden.</p>
-<h2>How might this cause problems?</h2>
+<h2 id="how-might-this-cause-problems">How might this cause problems?</h2>
 <p>Let's say that you have a very high profile project under your GitHub account
 that lots of people rely on. Let's also suppose that this is the definitive
 installation source.</p>
@@ -176,7 +176,7 @@ if there was some kind of short delay and an email warning before
 labelling your account as "not human", at least you'd have a chance to
 fix up your account first, without your account temporarily becoming a
 Ghost of GitHub Past.</p>
-<h2>What's the relevance to other online services?</h2>
+<h2 id="whats-the-relevance-to-other-online-services">What's the relevance to other online services?</h2>
 <p>This kind of situation isn't restricted specifically to GitHub. It does
 illustrate features of online services that are ever present, but remain
 latent until you encounter them. These are likely some variant of:</p>
@@ -202,7 +202,7 @@ latent until you encounter them. These are likely some variant of:</p>
   out because you don't even know what you did wrong.</p>
 </li>
 </ul>
-<h2>More on GitHub</h2>
+<h2 id="more-on-github">More on GitHub</h2>
 <p>OK, diversion aside, let's go back to speculating about GitHub accounts.
 Let's go further than hiding my account for a short time. What if my
 GitHub account was disabled entirely either for some period of time, or
@@ -313,14 +313,14 @@ realm of DJ tools that work magnificently live.&#160;<a class="footnote-backref"
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/windows-10-installation-impressions.html
+++ b/posts/windows-10-installation-impressions.html
@@ -130,7 +130,7 @@ issues. As far as I can tell, there's no separate checker you can run.
 If, like me, you disabled that annoying application, you'll want to
 re-enable it and see if there are any potential issues from any
 applications or hardware you have.</p>
-<h2>Clean installation</h2>
+<h2 id="clean-installation">Clean installation</h2>
 <p>Clean installation is a lot simpler than when Windows 10 was first
 launched, if you're claiming a free upgrade. Since the Threshold release
 last year, you can simply enter your existing Windows 7/8 product key,
@@ -140,7 +140,7 @@ installation solely to claim a digital entitlement, and then reinstall.</p>
 simple enough to navigate. Boot up the installer, select language
 options, choose where you want to install the operating system, wait a
 few minutes and you should soon have a working Windows install.</p>
-<h3>Drivers</h3>
+<h3 id="drivers">Drivers</h3>
 <p>In the past, even as recently as Windows 7, installing hardware was a
 mess in that you'd often have to trawl badly designed hardware
 manufacturer websites for several drivers you'd need to make everything
@@ -157,7 +157,7 @@ manufacturer, it was a particularly pleasant surprise to find that
 almost everything had been correctly installed. The main exception I
 found was a Native Instruments audio interface, but I realise that's not
 common hardware.</p>
-<h2>Updates</h2>
+<h2 id="updates">Updates</h2>
 <p>One of <em>the</em> major drawbacks of Windows past is the update system. A
 fresh install of Windows 7 now requires in excess of two hundred
 updates, which greatly extends the time to complete the install. You'll
@@ -193,7 +193,7 @@ hours on my ancient Core2Duo PC. If this new method of rolling out
 updates avoids this, it will prevent much user frustration as the
 operating system gets older, particularly if, as Microsoft claim, this
 is the "last version" of Windows.</p>
-<h2>Upgrade install</h2>
+<h2 id="upgrade-install">Upgrade install</h2>
 <p>I'm not a huge fan of upgrade installs with Windows. Usually, if a full
 installation is warranted, enough time has passed that it's often
 worthwhile to do a clean install. In one case I dealt with, I felt it
@@ -208,7 +208,7 @@ You can download a USB creator or ISO from Microsoft's site, and run
 any problems following it. Microsoft do blatantly ignore your existing
 choice of browser and select Edge as the default for you though...
 thanks for that.</p>
-<h2>And after installation?</h2>
+<h2 id="and-after-installation">And after installation?</h2>
 <p>Despite it being out almost a year, I'm only really now starting to use
 Windows 10 on a regular basis. Where possible, I'd rather hold off if I
 have systems that are working well and let others find and report bugs.</p>
@@ -219,7 +219,7 @@ versions of Windows. What you should be reading is this page on
 <a href="https://technet.microsoft.com/en-us/itpro/windows/manage/configure-windows-telemetry-in-your-organization">Microsoft's site that details
 telemetry</a>
 to tell you exactly what can be disabled.</p>
-<h3>Other problems</h3>
+<h3 id="other-problems">Other problems</h3>
 <p>Several other things I don't like have emerged over the few hours I've
 used Windows 10.</p>
 <ol>
@@ -286,7 +286,7 @@ used Windows 10.</p>
    still remains. Otherwise, changes made disappear once you log out.</p>
 </li>
 </ol>
-<h2>But Windows 10 is worth a try</h2>
+<h2 id="but-windows-10-is-worth-a-try">But Windows 10 is worth a try</h2>
 <p>That's a long list of complaints, but actually I'm more positive about
 Windows 10 than that might suggest. My near-decade old PC with an SSD
 boots Windows 10 in around twenty seconds from power on, which feels
@@ -361,14 +361,14 @@ reinstall whichever extras for that game required it.&#160;<a class="footnote-ba
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/windows-update-locking-up-on-xp-when.html
+++ b/posts/windows-update-locking-up-on-xp-when.html
@@ -214,14 +214,14 @@ though...</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/posts/working-with-multiple-ssh-keys-setting.html
+++ b/posts/working-with-multiple-ssh-keys-setting.html
@@ -207,14 +207,14 @@ this unless you're an admin of the repository.&#160;<a class="footnote-backref" 
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/100.html
+++ b/tag/100.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/1204.html
+++ b/tag/1204.html
@@ -156,14 +156,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/academia.html
+++ b/tag/academia.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/academic.html
+++ b/tag/academic.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/activation.html
+++ b/tag/activation.html
@@ -134,14 +134,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ad.html
+++ b/tag/ad.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/adapter.html
+++ b/tag/adapter.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/adblock.html
+++ b/tag/adblock.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/advert.html
+++ b/tag/advert.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/aero.html
+++ b/tag/aero.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/airprint.html
+++ b/tag/airprint.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/anacron.html
+++ b/tag/anacron.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/analytics.html
+++ b/tag/analytics.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/android.html
+++ b/tag/android.html
@@ -274,14 +274,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/annoyance.html
+++ b/tag/annoyance.html
@@ -171,14 +171,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/app.html
+++ b/tag/app.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/article.html
+++ b/tag/article.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/assembly.html
+++ b/tag/assembly.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/asus.html
+++ b/tag/asus.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ata.html
+++ b/tag/ata.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/audio.html
+++ b/tag/audio.html
@@ -177,14 +177,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/auto-patcher.html
+++ b/tag/auto-patcher.html
@@ -175,14 +175,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/backup.html
+++ b/tag/backup.html
@@ -185,14 +185,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bash.html
+++ b/tag/bash.html
@@ -154,14 +154,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/beat-grid.html
+++ b/tag/beat-grid.html
@@ -138,14 +138,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/beatmatching.html
+++ b/tag/beatmatching.html
@@ -173,14 +173,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/beautifulsoup.html
+++ b/tag/beautifulsoup.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/big.html
+++ b/tag/big.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bitbucket.html
+++ b/tag/bitbucket.html
@@ -163,14 +163,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bitlocker.html
+++ b/tag/bitlocker.html
@@ -313,14 +313,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/black.html
+++ b/tag/black.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/blocking.html
+++ b/tag/blocking.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/blog.html
+++ b/tag/blog.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/blogger.html
+++ b/tag/blogger.html
@@ -195,14 +195,14 @@ generators.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/blogging.html
+++ b/tag/blogging.html
@@ -177,14 +177,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bokeh.html
+++ b/tag/bokeh.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/book-review.html
+++ b/tag/book-review.html
@@ -136,14 +136,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/book.html
+++ b/tag/book.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/boot.html
+++ b/tag/boot.html
@@ -156,14 +156,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/bug.html
+++ b/tag/bug.html
@@ -177,14 +177,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/build.html
+++ b/tag/build.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/business.html
+++ b/tag/business.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/cambridge.html
+++ b/tag/cambridge.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/career.html
+++ b/tag/career.html
@@ -214,14 +214,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/careers.html
+++ b/tag/careers.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/centrino.html
+++ b/tag/centrino.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/charging.html
+++ b/tag/charging.html
@@ -154,14 +154,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/chromium.html
+++ b/tag/chromium.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/citrix.html
+++ b/tag/citrix.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/clean.html
+++ b/tag/clean.html
@@ -156,14 +156,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/coding.html
+++ b/tag/coding.html
@@ -181,14 +181,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/communication.html
+++ b/tag/communication.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/connection.html
+++ b/tag/connection.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/convert.html
+++ b/tag/convert.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/course.html
+++ b/tag/course.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/coursera.html
+++ b/tag/coursera.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/cpu.html
+++ b/tag/cpu.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/cron.html
+++ b/tag/cron.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/data.html
+++ b/tag/data.html
@@ -276,14 +276,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/dban.html
+++ b/tag/dban.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/delay.html
+++ b/tag/delay.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/dependency.html
+++ b/tag/dependency.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/desktop.html
+++ b/tag/desktop.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/development.html
+++ b/tag/development.html
@@ -179,14 +179,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/device.html
+++ b/tag/device.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/digital.html
+++ b/tag/digital.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/disk.html
+++ b/tag/disk.html
@@ -175,14 +175,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/dj.html
+++ b/tag/dj.html
@@ -173,14 +173,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/dm-crypt.html
+++ b/tag/dm-crypt.html
@@ -156,14 +156,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/documentation.html
+++ b/tag/documentation.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/domain.html
+++ b/tag/domain.html
@@ -138,14 +138,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/draft.html
+++ b/tag/draft.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/drive.html
+++ b/tag/drive.html
@@ -224,14 +224,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/driver.html
+++ b/tag/driver.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/editing.html
+++ b/tag/editing.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/email.html
+++ b/tag/email.html
@@ -136,14 +136,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/enclosure.html
+++ b/tag/enclosure.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/encryption.html
+++ b/tag/encryption.html
@@ -290,14 +290,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/epson.html
+++ b/tag/epson.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/erase.html
+++ b/tag/erase.html
@@ -200,14 +200,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/error.html
+++ b/tag/error.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/expressions.html
+++ b/tag/expressions.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/external.html
+++ b/tag/external.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/firefox.html
+++ b/tag/firefox.html
@@ -188,14 +188,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/firmware.html
+++ b/tag/firmware.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/fix.html
+++ b/tag/fix.html
@@ -259,14 +259,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/fl.html
+++ b/tag/fl.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/folder.html
+++ b/tag/folder.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/foolishness.html
+++ b/tag/foolishness.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/forerunner.html
+++ b/tag/forerunner.html
@@ -172,14 +172,14 @@ watch was definitely a great budget choice.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/fraction.html
+++ b/tag/fraction.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/free.html
+++ b/tag/free.html
@@ -156,14 +156,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/freeze.html
+++ b/tag/freeze.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/g300.html
+++ b/tag/g300.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/garmin.html
+++ b/tag/garmin.html
@@ -172,14 +172,14 @@ watch was definitely a great budget choice.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/get_iplayer.html
+++ b/tag/get_iplayer.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/github.html
+++ b/tag/github.html
@@ -196,14 +196,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/gmail.html
+++ b/tag/gmail.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/golang.html
+++ b/tag/golang.html
@@ -136,14 +136,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/gotomeeting.html
+++ b/tag/gotomeeting.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/gps.html
+++ b/tag/gps.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/hdd.html
+++ b/tag/hdd.html
@@ -185,14 +185,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/hdparm.html
+++ b/tag/hdparm.html
@@ -165,14 +165,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/heartbleed.html
+++ b/tag/heartbleed.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/heatsink.html
+++ b/tag/heatsink.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/high.html
+++ b/tag/high.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/hog.html
+++ b/tag/hog.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/http-switchboard.html
+++ b/tag/http-switchboard.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/imagemagick.html
+++ b/tag/imagemagick.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/imap.html
+++ b/tag/imap.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ink.html
+++ b/tag/ink.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/install.html
+++ b/tag/install.html
@@ -177,14 +177,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/installation.html
+++ b/tag/installation.html
@@ -134,14 +134,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/intel.html
+++ b/tag/intel.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/iplayer.html
+++ b/tag/iplayer.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ipod.html
+++ b/tag/ipod.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/iso.html
+++ b/tag/iso.html
@@ -136,14 +136,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/jekyll.html
+++ b/tag/jekyll.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/job.html
+++ b/tag/job.html
@@ -249,14 +249,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/journal.html
+++ b/tag/journal.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/juniper.html
+++ b/tag/juniper.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/kernel.html
+++ b/tag/kernel.html
@@ -156,14 +156,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/key.html
+++ b/tag/key.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/keyboard.html
+++ b/tag/keyboard.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/keyword-search.html
+++ b/tag/keyword-search.html
@@ -136,14 +136,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/lag.html
+++ b/tag/lag.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/laptop.html
+++ b/tag/laptop.html
@@ -177,14 +177,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/latency.html
+++ b/tag/latency.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/leaky.html
+++ b/tag/leaky.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/learning.html
+++ b/tag/learning.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/led.html
+++ b/tag/led.html
@@ -154,14 +154,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/level.html
+++ b/tag/level.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/linux.html
+++ b/tag/linux.html
@@ -284,14 +284,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/logitech.html
+++ b/tag/logitech.html
@@ -154,14 +154,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/lts.html
+++ b/tag/lts.html
@@ -156,14 +156,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/luks.html
+++ b/tag/luks.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/lxml.html
+++ b/tag/lxml.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/mailinator.html
+++ b/tag/mailinator.html
@@ -136,14 +136,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/main.html
+++ b/tag/main.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/matplotlib.html
+++ b/tag/matplotlib.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/midi.html
+++ b/tag/midi.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/migration.html
+++ b/tag/migration.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/mock.html
+++ b/tag/mock.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/motherboard.html
+++ b/tag/motherboard.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/moto.html
+++ b/tag/moto.html
@@ -181,14 +181,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/mouse.html
+++ b/tag/mouse.html
@@ -154,14 +154,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/music.html
+++ b/tag/music.html
@@ -175,14 +175,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/musings.html
+++ b/tag/musings.html
@@ -134,14 +134,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/mx.html
+++ b/tag/mx.html
@@ -154,14 +154,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/name.html
+++ b/tag/name.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/namecheap.html
+++ b/tag/namecheap.html
@@ -138,14 +138,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/nano.html
+++ b/tag/nano.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/nature.html
+++ b/tag/nature.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/naturejobs.html
+++ b/tag/naturejobs.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/open-source.html
+++ b/tag/open-source.html
@@ -134,14 +134,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/open.html
+++ b/tag/open.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/partition.html
+++ b/tag/partition.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pc.html
+++ b/tag/pc.html
@@ -181,14 +181,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pdf.html
+++ b/tag/pdf.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pdroid.html
+++ b/tag/pdroid.html
@@ -212,14 +212,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pelican.html
+++ b/tag/pelican.html
@@ -234,14 +234,14 @@ generators.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/phd.html
+++ b/tag/phd.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pi.html
+++ b/tag/pi.html
@@ -224,14 +224,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ping.html
+++ b/tag/ping.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/plot.html
+++ b/tag/plot.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/plugin.html
+++ b/tag/plugin.html
@@ -136,14 +136,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pop.html
+++ b/tag/pop.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/postdoc.html
+++ b/tag/postdoc.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/printer.html
+++ b/tag/printer.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/privacy.html
+++ b/tag/privacy.html
@@ -185,14 +185,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/production.html
+++ b/tag/production.html
@@ -175,14 +175,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/programming.html
+++ b/tag/programming.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/publishing.html
+++ b/tag/publishing.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pyc.html
+++ b/tag/pyc.html
@@ -138,14 +138,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pygtk.html
+++ b/tag/pygtk.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/pypi.html
+++ b/tag/pypi.html
@@ -134,14 +134,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/python.html
+++ b/tag/python.html
@@ -444,14 +444,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/python2.html
+++ b/tag/python2.html
@@ -179,14 +179,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/quick-search.html
+++ b/tag/quick-search.html
@@ -136,14 +136,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/radio.html
+++ b/tag/radio.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/raspberry.html
+++ b/tag/raspberry.html
@@ -224,14 +224,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/raspbian.html
+++ b/tag/raspbian.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/recording.html
+++ b/tag/recording.html
@@ -138,14 +138,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/red.html
+++ b/tag/red.html
@@ -154,14 +154,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/registrar.html
+++ b/tag/registrar.html
@@ -138,14 +138,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/regular.html
+++ b/tag/regular.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/remote.html
+++ b/tag/remote.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/research.html
+++ b/tag/research.html
@@ -214,14 +214,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/researcher.html
+++ b/tag/researcher.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/respawn.html
+++ b/tag/respawn.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/review.html
+++ b/tag/review.html
@@ -172,14 +172,14 @@ watch was definitely a great budget choice.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/revolution.html
+++ b/tag/revolution.html
@@ -154,14 +154,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/rockbox.html
+++ b/tag/rockbox.html
@@ -165,14 +165,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/root.html
+++ b/tag/root.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/running.html
+++ b/tag/running.html
@@ -172,14 +172,14 @@ watch was definitely a great budget choice.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/samba.html
+++ b/tag/samba.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/schedule.html
+++ b/tag/schedule.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/science.html
+++ b/tag/science.html
@@ -239,14 +239,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/scikit-learn.html
+++ b/tag/scikit-learn.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/scraping.html
+++ b/tag/scraping.html
@@ -183,14 +183,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/screen.html
+++ b/tag/screen.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/screenshot.html
+++ b/tag/screenshot.html
@@ -134,14 +134,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/script.html
+++ b/tag/script.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/secure-boot.html
+++ b/tag/secure-boot.html
@@ -138,14 +138,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/secure.html
+++ b/tag/secure.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/security.html
+++ b/tag/security.html
@@ -181,14 +181,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/self-indulgence.html
+++ b/tag/self-indulgence.html
@@ -134,14 +134,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/server.html
+++ b/tag/server.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/shell.html
+++ b/tag/shell.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/site.html
+++ b/tag/site.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/slam.html
+++ b/tag/slam.html
@@ -154,14 +154,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/software.html
+++ b/tag/software.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/solution.html
+++ b/tag/solution.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/source.html
+++ b/tag/source.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/space.html
+++ b/tag/space.html
@@ -156,14 +156,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ssh.html
+++ b/tag/ssh.html
@@ -175,14 +175,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/startup.html
+++ b/tag/startup.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/static-site.html
+++ b/tag/static-site.html
@@ -143,14 +143,14 @@ generators.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/static.html
+++ b/tag/static.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/studio.html
+++ b/tag/studio.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/sync.html
+++ b/tag/sync.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/system.html
+++ b/tag/system.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/tablet.html
+++ b/tag/tablet.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/tag-cloud.html
+++ b/tag/tag-cloud.html
@@ -136,14 +136,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/tech.html
+++ b/tag/tech.html
@@ -148,14 +148,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/test.html
+++ b/tag/test.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/testing.html
+++ b/tag/testing.html
@@ -181,14 +181,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/theme.html
+++ b/tag/theme.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/thunderbird.html
+++ b/tag/thunderbird.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/tracklisting.html
+++ b/tag/tracklisting.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/traktor.html
+++ b/tag/traktor.html
@@ -173,14 +173,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/transfer.html
+++ b/tag/transfer.html
@@ -138,14 +138,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/trim.html
+++ b/tag/trim.html
@@ -156,14 +156,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/truecrypt.html
+++ b/tag/truecrypt.html
@@ -189,14 +189,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ublock.html
+++ b/tag/ublock.html
@@ -185,14 +185,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/ubuntu.html
+++ b/tag/ubuntu.html
@@ -449,14 +449,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/uninstall.html
+++ b/tag/uninstall.html
@@ -140,14 +140,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/unit.html
+++ b/tag/unit.html
@@ -144,14 +144,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/university.html
+++ b/tag/university.html
@@ -214,14 +214,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/unrecognized.html
+++ b/tag/unrecognized.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/update.html
+++ b/tag/update.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/upgrade.html
+++ b/tag/upgrade.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/usb.html
+++ b/tag/usb.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/vacancy.html
+++ b/tag/vacancy.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/video.html
+++ b/tag/video.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/virtualenv.html
+++ b/tag/virtualenv.html
@@ -216,14 +216,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/vst.html
+++ b/tag/vst.html
@@ -150,14 +150,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/web.html
+++ b/tag/web.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/wifi.html
+++ b/tag/wifi.html
@@ -212,14 +212,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/windows.html
+++ b/tag/windows.html
@@ -411,14 +411,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/wireless.html
+++ b/tag/wireless.html
@@ -181,14 +181,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/wordpress.html
+++ b/tag/wordpress.html
@@ -253,14 +253,14 @@ generators.</p>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/xp.html
+++ b/tag/xp.html
@@ -152,14 +152,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/xprivacy.html
+++ b/tag/xprivacy.html
@@ -146,14 +146,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tag/youtube.html
+++ b/tag/youtube.html
@@ -142,14 +142,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">

--- a/tags.html
+++ b/tags.html
@@ -3288,14 +3288,14 @@ stevenmaude.co.uk            </a>
                             Linux
                         </a>
                     </li>
+                    <li class="list-group-item tag-2">
+                        <a href="http://www.stevenmaude.co.uk/tag/pelican">
+                            Pelican
+                        </a>
+                    </li>
                     <li class="list-group-item tag-1">
                         <a href="http://www.stevenmaude.co.uk/tag/python">
                             Python
-                        </a>
-                    </li>
-                    <li class="list-group-item tag-2">
-                        <a href="http://www.stevenmaude.co.uk/tag/science">
-                            science
                         </a>
                     </li>
                     <li class="list-group-item tag-1">


### PR DESCRIPTION
Use the Python Markdown toc extension to auto-generate ids so that
sections of documents can be linked to.