### PR TITLE
Use h2 headings instead of h1

### DIFF
--- a/feeds/all.atom.xml
+++ b/feeds/all.atom.xml
@@ -8,7 +8,7 @@ below&lt;/a&gt;.)&lt;/p&gt;
 boot into Windows. Nonetheless, I had a little time spare last week, I figured
 I might as well catch up on things everywhere and update the Windows install.&lt;/p&gt;
 &lt;p&gt;Dropping into that did update Windows, and all well and good. Or so I thought.&lt;/p&gt;
-&lt;h1 id="the-problem"&gt;The problem&lt;/h1&gt;
+&lt;h2 id="the-problem"&gt;The problem&lt;/h2&gt;
 &lt;p&gt;On restarting, I noticed there was a Fujitsu prompt that appeared, and was a
 little unexpected. What I was being asked to install was the very precisely
 named "Battery Charging Control Update Tool". It seems &lt;a href="https://www.fujitsu.com/global/about/resources/news/notices/2018/1031-01.html"&gt;Fujitsu have had some
@@ -31,7 +31,7 @@ loudly somewhere about a problem you've encountered too. &lt;/p&gt;
 &lt;p&gt;Anyway, I rebooted and tried the update again. Same result. Blue screen.&lt;/p&gt;
 &lt;p&gt;OK then. Third time lucky, maybe? No. Just the same (reliably) unreliable
 result.&lt;/p&gt;
-&lt;h1 id="the-fix"&gt;The fix&lt;/h1&gt;
+&lt;h2 id="the-fix"&gt;The fix&lt;/h2&gt;
 &lt;p&gt;In a moment of fortunate (and rare) inspiration, I remembered that I'd turned on a
 relatively new security feature — &lt;a href="https://support.microsoft.com/en-us/help/4096339/windows-10-device-protection-in-windows-defender-security-center"&gt;Memory
 Integrity&lt;/a&gt;

--- a/posts/stopping-fujitsus-battery-charging-control-update-tool-from-crashing-windows-10.html
+++ b/posts/stopping-fujitsus-battery-charging-control-update-tool-from-crashing-windows-10.html
@@ -120,7 +120,7 @@ below</a>.)</p>
 boot into Windows. Nonetheless, I had a little time spare last week, I figured
 I might as well catch up on things everywhere and update the Windows install.</p>
 <p>Dropping into that did update Windows, and all well and good. Or so I thought.</p>
-<h1 id="the-problem">The problem</h1>
+<h2 id="the-problem">The problem</h2>
 <p>On restarting, I noticed there was a Fujitsu prompt that appeared, and was a
 little unexpected. What I was being asked to install was the very precisely
 named "Battery Charging Control Update Tool". It seems <a href="https://www.fujitsu.com/global/about/resources/news/notices/2018/1031-01.html">Fujitsu have had some
@@ -143,7 +143,7 @@ loudly somewhere about a problem you've encountered too. </p>
 <p>Anyway, I rebooted and tried the update again. Same result. Blue screen.</p>
 <p>OK then. Third time lucky, maybe? No. Just the same (reliably) unreliable
 result.</p>
-<h1 id="the-fix">The fix</h1>
+<h2 id="the-fix">The fix</h2>
 <p>In a moment of fortunate (and rare) inspiration, I remembered that I'd turned on a
 relatively new security feature — <a href="https://support.microsoft.com/en-us/help/4096339/windows-10-device-protection-in-windows-defender-security-center">Memory
 Integrity</a>


### PR DESCRIPTION
h1 is used for the title of the page. This corrects the heading
hierarchy; the title should be a higher level than the section headings.